### PR TITLE
Add error handler to parser

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,7 +1,7 @@
 # API Reference
 * [groq-js](#module_groq-js)
     * [.evaluate(tree, [options])](#module_groq-js.evaluate) ⇒ [<code>Value</code>](#Value)
-    * [.parse(input)](#module_groq-js.parse) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
+    * [.parse(input, [errorHandler])](#module_groq-js.parse) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
 
 
 <a name="module_groq-js.evaluate"></a>
@@ -21,7 +21,7 @@ Evaluates a syntax tree (which you can get from [parse](#module_groq-js.parse)).
 
 <a name="module_groq-js.parse"></a>
 
-### groq-js.parse(input) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
+### groq-js.parse(input, [errorHandler]) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
 Parses a GROQ query and returns a tree structure.
 
 **Kind**: static method of [<code>groq-js</code>](#module_groq-js)  
@@ -29,6 +29,7 @@ Parses a GROQ query and returns a tree structure.
 | Param | Type | Description |
 | --- | --- | --- |
 | input | <code>string</code> | GROQ query |
+| errorHandler | <code>function</code> | Function to handler parsing errors |
 
 
 <a name="Value"></a>

--- a/API.md
+++ b/API.md
@@ -1,7 +1,7 @@
 # API Reference
 * [groq-js](#module_groq-js)
     * [.evaluate(tree, [options])](#module_groq-js.evaluate) ⇒ [<code>Value</code>](#Value)
-    * [.parse(input, [errorHandler])](#module_groq-js.parse) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
+    * [.parse(input)](#module_groq-js.parse) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
 
 
 <a name="module_groq-js.evaluate"></a>
@@ -21,7 +21,7 @@ Evaluates a syntax tree (which you can get from [parse](#module_groq-js.parse)).
 
 <a name="module_groq-js.parse"></a>
 
-### groq-js.parse(input, [errorHandler]) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
+### groq-js.parse(input) ⇒ [<code>SyntaxNode</code>](#SyntaxNode)
 Parses a GROQ query and returns a tree structure.
 
 **Kind**: static method of [<code>groq-js</code>](#module_groq-js)  
@@ -29,7 +29,6 @@ Parses a GROQ query and returns a tree structure.
 | Param | Type | Description |
 | --- | --- | --- |
 | input | <code>string</code> | GROQ query |
-| errorHandler | <code>function</code> | Function to handler parsing errors |
 
 
 <a name="Value"></a>

--- a/src/parser.js
+++ b/src/parser.js
@@ -528,22 +528,25 @@ function extractPropertyKey(node) {
   throw new Error('Cannot determine property key for type: ' + node.type)
 }
 
-function defaultErrorHandler() {
-  throw new Error('Syntax error in GROQ query')
+class GroqSyntaxError extends Error {
+  constructor(position) {
+    super(`Syntax error in GROQ query at position ${position}`)
+    this.position = position;
+    this.name = "GroqSyntaxError"
+  }
 }
 
 /**
  * Parses a GROQ query and returns a tree structure.
  * 
  * @param {string} input GROQ query
- * @param {function} errorHandler Function to handle parsing errors
  * @returns {SyntaxNode}
  * @alias module:groq-js.parse
  * @static
  */
-function parse(input, errorHandler = defaultErrorHandler) {
+function parse(input) {
   let result = rawParse(input)
-  if (result.type === 'error') return errorHandler(result)
+  if (result.type === 'error') throw new GroqSyntaxError(result.position)
   let processor = new MarkProcessor(BUILDER, input, result.marks)
   return processor.process()
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -528,17 +528,22 @@ function extractPropertyKey(node) {
   throw new Error('Cannot determine property key for type: ' + node.type)
 }
 
+function defaultErrorHandler() {
+  throw new Error('Syntax error in GROQ query')
+}
+
 /**
  * Parses a GROQ query and returns a tree structure.
  * 
  * @param {string} input GROQ query
+ * @param {function} errorHandler Function to handle parsing errors
  * @returns {SyntaxNode}
  * @alias module:groq-js.parse
  * @static
  */
-function parse(input) {
+function parse(input, errorHandler = defaultErrorHandler) {
   let result = rawParse(input)
-  if (result.type === 'error') throw new Error('Syntax error in GROQ query')
+  if (result.type === 'error') return errorHandler(result)
   let processor = new MarkProcessor(BUILDER, input, result.marks)
   return processor.process()
 }

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -7,3 +7,16 @@ describe("Basic parsing", () => {
     expect(tree).toMatchSnapshot();
   })
 })
+
+describe("Error reporting", () => {
+  test("Query with syntax error", () => {
+    let query = `*[_type == "]`
+    try {
+      parse(query);
+    } catch(error) {
+      expect(error.name).toBe("GroqSyntaxError")
+      expect(error.position).toBe(13)
+      expect(error.message).toBe("Syntax error in GROQ query at position 13")
+    }
+  });
+})


### PR DESCRIPTION
*What:* Adds an `errorHandler` (function) argument to `parse`, which is called with the result object when there's an error. The default value for `errorHandler` is a function that throws an error.

*Why:* I want to use this for an eslint plugin to validate tagged groq queries in javascript, but it turns out that the error message `"Syntax error in GROQ query"` is not that helpful for large queries. The raw parser is more helpful (returning a `position`), but as far as I can tell the raw parser is not a part of the public API, so I'm not as comfortable using that directly. An error handler that exposes the `result` object from the raw parser solves this.

Here's an image for a bit more context (spot the typo!):

![bilde](https://user-images.githubusercontent.com/13281350/66757241-06ecc580-ee9c-11e9-8bee-68c99ab23cbe.png)
