### PR TITLE
Implement now() function (fixes #8)

### DIFF
--- a/src/evaluator/functions.js
+++ b/src/evaluator/functions.js
@@ -161,6 +161,12 @@ functions.round = async function round(args, scope, execute) {
   }
 }
 
+functions.now = async function now(args, scope, execute) {
+  if (args.length != 0) throw new Error('now: no arguments are allowed')
+
+  return new StaticValue(scope.timestamp)
+}
+
 pipeFunctions.order = async function order(base, args, scope, execute) {
   if (args.length == 0) throw new Error('order: at least one argument required')
   if (base.getType() != 'array') return NULL_VALUE

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -33,6 +33,7 @@ class Scope {
     this.source = source
     this.value = value
     this.parent = parent
+    this.timestamp = parent ? parent.timestamp : new Date().toISOString()
   }
 
   createNested(value) {

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -1,0 +1,35 @@
+const {evaluate, parse} = require('../src')
+
+describe('Functions', () => {
+  describe('now()', () => {
+    test('returns iso-8601 timestamp', async () => {
+      let tree = parse('now()')
+      let value = await evaluate(tree, {dataset: []})
+      let data = await value.get()
+
+      expect(typeof data).toBe('string')
+
+      // Allow a ~5s shift to account for lag
+      expect(Date.parse(data)).toBeGreaterThan(Date.now() - 5000)
+    })
+
+    test('returns the same value for each use in query', async () => {
+      let dataset = [
+        {_type: 'product', deep: {deep: {deep: {deep: {deep: {deep: {text: 'value'}}}}}}}
+      ]
+      let query = `{
+        "topTime": now(),
+        "deep": *[_type == "product"][0].deep.deep.deep.deep.deep.deep { text, "time": now() }
+      }`
+      let tree = parse(query)
+      let value = await evaluate(tree, {dataset})
+      let data = await value.get()
+      expect(data.deep.time).toStrictEqual(data.topTime)
+    })
+
+    test('throws is passing arguments', async () => {
+      let tree = parse('now("foo")')
+      return expect(evaluate(tree, {dataset: []})).rejects.toThrow('now: no arguments are allowed')
+    })
+  })
+})


### PR DESCRIPTION
This implements `now()` as-is. 

I'm curious if you think we should make this return a `dateTime`, or match the current behavior which returns an ISO-8601 timestamp?

