### PR TITLE
Support concatenation of arrays

### DIFF
--- a/src/evaluator/operators.ts
+++ b/src/evaluator/operators.ts
@@ -160,6 +160,10 @@ export const operators: {[key in GroqOperator]: GroqOperatorFn} = {
       return new StaticValue((await a.get()) + (await b.get()))
     }
 
+    if (aType === 'array' && bType === 'array') {
+      return new StaticValue((await a.get()).concat(await b.get()))
+    }
+
     return NULL_VALUE
   },
 


### PR DESCRIPTION
`[1] + [2]` is currently resulting in `null`, whereas the spec says it should return `[1, 2]`. 