### PR TITLE
Fix ES Module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,16 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "10",
+          "chrome": "59",
+          "safari": "10",
+          "firefox": "56",
+          "edge": "14"
+        }
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^15.1.0",
     "@types/jest": "^26.0.14",
     "ndjson": "^2.0.0",
     "tsdx": "^0.14.0",

--- a/src/evaluator/value.ts
+++ b/src/evaluator/value.ts
@@ -61,6 +61,10 @@ export class StaticValue<P = any> {
   }
 }
 
+export const NULL_VALUE = new StaticValue(null)
+export const TRUE_VALUE = new StaticValue(true)
+export const FALSE_VALUE = new StaticValue(false)
+
 /**
  * A StreamValue accepts a generator which yields values.
  */
@@ -247,7 +251,7 @@ export function fromNumber(num: number) {
   if (Number.isFinite(num)) {
     return new StaticValue(num)
   } else {
-    return exports.NULL_VALUE
+    return NULL_VALUE
   }
 }
 
@@ -263,12 +267,8 @@ export function fromJS(val: any) {
       }
     })
   } else if (val === null || val === undefined) {
-    return exports.NULL_VALUE
+    return NULL_VALUE
   } else {
     return new StaticValue(val)
   }
 }
-
-export const NULL_VALUE = new StaticValue(null)
-export const TRUE_VALUE = new StaticValue(true)
-export const FALSE_VALUE = new StaticValue(false)

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -145,7 +145,7 @@ function addNextFrame(step, frame) {
   }
 }
 
-function recognize(input) {
+export function recognize(input) {
   var frames = initialFrames;
 
   var i = 0;
@@ -180,7 +180,7 @@ function flattenMarks(marks) {
   return result;
 }
 
-function parse(input) {
+export function parse(input) {
   var frames = initialFrames;
 
   var i = 0;
@@ -2771,5 +2771,3 @@ ruleInitialStates["EXPR^7"] = [state260];
 ruleInitialStates["EXPR^9"] = [state280];
 ruleInitialStates["EXPR^11"] = [state289];
 
-exports.recognize = recognize;
-exports.parse = parse;

--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,8 +1,0 @@
-const commonjs = require('@rollup/plugin-commonjs')
-
-module.exports = {
-  rollup(config, options) {
-    config.plugins.push(commonjs())
-    return config
-  }
-}


### PR DESCRIPTION
Had some real trouble getting the ESM bundle to work. 

- The `evaluator/value.ts` file is referencing `exports.NULL_VALUE`, which it shouldn't in typescript environment (probably an oversight on my part when converting to typescript)
- The raw parser being CommonJS leads to some unnecessary complications and "interop" modes
- tsdx is including the regenerator runtime, which is causing a pretty massive bundle as well as several references to `module.exports`

This PR:
- Switches to using ESM-style exports of the two exported functions in the raw parser - hope that's ok. Not sure what generates/generated this file, but maybe that should be fixed too.
- Uses the constants  `NULL_VALUE` and  `TRUE_VALUE` instead of referencing `exports.*`
- Adds a babelrc with browser and node.js target specified. This means the module will now only work on edge 14 and up, but that seems like a very fair trade-off in my eyes
 