### PR TITLE
Implement string function

### DIFF
--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -139,6 +139,23 @@ functions.select = async function select(args, scope, execute) {
   return NULL_VALUE
 }
 
+functions.string = async function string(args, scope, execute) {
+  let value = await execute(args[0], scope)
+  switch (value.getType()) {
+    case 'array':
+      return new StaticValue((await value.get()).join(','));
+    case 'object':
+      return new StaticValue(JSON.stringify(await value.get()));
+    case 'number':
+    case 'string':
+    case 'boolean':
+      return new StaticValue('' + await value.get());
+    default:
+      return NULL_VALUE;
+  }
+}
+functions.string.arity = 1
+
 functions.references = async function references(args, scope, execute) {
   let idValue = await execute(args[0], scope)
   if (idValue.getType() !== 'string') return FALSE_VALUE

--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -142,10 +142,6 @@ functions.select = async function select(args, scope, execute) {
 functions.string = async function string(args, scope, execute) {
   let value = await execute(args[0], scope)
   switch (value.getType()) {
-    case 'array':
-      return new StaticValue((await value.get()).join(','));
-    case 'object':
-      return new StaticValue(JSON.stringify(await value.get()));
     case 'number':
     case 'string':
     case 'boolean':

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -25,7 +25,7 @@ describe('Basic parsing', () => {
 
     let value = await evaluate(tree, {dataset})
     let data = await value.get()
-    expect(data).toStrictEqual([{ class: 'red-600', rgb: "{\"r\":255,\"g\":0,\"b\":0}" }, { class: 'green-600', rgb: "{\"r\":0,\"g\":255,\"b\":0}" }])
+    expect(data).toStrictEqual([{ class: 'red-600' }, { class: 'green-600' }])
   })
 
   test('Controlling this', async () => {

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -15,6 +15,19 @@ describe('Basic parsing', () => {
     expect(data).toStrictEqual([{name: 'T-shirt'}, {name: 'Pants'}])
   })
 
+  test('String function', async () => {
+    let dataset = [
+      {_type: 'color', color: 'red', shade: 500, rgb: { r: 255, g: 0, b: 0 }},
+      {_type: 'color', color: 'green', shade: 500, rgb: { r: 0, g: 255, b: 0 }},
+    ]
+    let query = `*[_type == "color"]{ "class": color + "-" + string(shade + 100), "rgb": string(rgb) }`
+    let tree = parse(query)
+
+    let value = await evaluate(tree, {dataset})
+    let data = await value.get()
+    expect(data).toStrictEqual([{ class: 'red-600', rgb: "{\"r\":255,\"g\":0,\"b\":0}" }, { class: 'green-600', rgb: "{\"r\":0,\"g\":255,\"b\":0}" }])
+  })
+
   test('Controlling this', async () => {
     let query = `@`
     let tree = parse(query)


### PR DESCRIPTION
There's a long standing issue (https://github.com/sanity-io/sanity/issues/1108) for this function and we recently bumped into an query that would benefit greatly of this type coercion possibility.

I took a stab at it and here's my proposal, the `string()` function takes one argument that can be an expression or a static value as with pretty much all other functions.

If the argument is a `boolean`, `number` or `string` the casting is pretty straightforward, for `array` the value is joined with a comma (`,`) and objects are `JSON.stringify`-ed.

I'd love to hear what you guys think about this!