### PR TITLE
Parse object expressions starting with string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug fixes
 
 - Correctly accept function calls with trailing commas: `select(123,)`.
+- Correctly parse object expressions which start with literal strings (e.g. `{"mail" == … => …}`).
 
 ## v0.4.0-beta.1
 

--- a/tap-snapshots/test/parse.test.ts.test.cjs
+++ b/tap-snapshots/test/parse.test.ts.test.cjs
@@ -48,6 +48,49 @@ Object {
 }
 `
 
+exports[`test/parse.test.ts TAP Basic parsing Object expression starting with string > must match snapshot 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "condition": Object {
+        "left": Object {
+          "type": "Value",
+          "value": "mail",
+        },
+        "op": "==",
+        "right": Object {
+          "type": "Value",
+          "value": 1,
+        },
+        "type": "OpCall",
+      },
+      "type": "ObjectConditionalSplat",
+      "value": Object {
+        "attributes": Array [],
+        "type": "Object",
+      },
+    },
+  ],
+  "type": "Object",
+}
+`
+
+exports[`test/parse.test.ts TAP Basic parsing Space after field in objects > must match snapshot 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "name": "mail",
+      "type": "ObjectAttributeValue",
+      "value": Object {
+        "type": "Value",
+        "value": 123,
+      },
+    },
+  ],
+  "type": "Object",
+}
+`
+
 exports[`test/parse.test.ts TAP Basic parsing Trailing comma in function call > must match snapshot 1`] = `
 Object {
   "alternatives": Array [],

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -14,6 +14,18 @@ t.test('Basic parsing', async (t) => {
     const tree = parse(query)
     t.matchSnapshot(tree)
   })
+
+  t.test('Object expression starting with string', async (t) => {
+    const query = `{"mail" == 1 => {}}`
+    const tree = parse(query)
+    t.matchSnapshot(tree)
+  })
+
+  t.test('Space after field in objects', async (t) => {
+    const query = `{"mail" : 123}`
+    const tree = parse(query)
+    t.matchSnapshot(tree)
+  })
 })
 
 t.test('Error reporting', async (t) => {


### PR DESCRIPTION
Previously when we saw `{"foo"` we would immediately start parsing it as a field (`{"foo":123}`). This is not correct since it's possible to write `{"foo" == bar => {…}}`). This changes the logic to always parse it as a general expression and if it ends up being parsed as a literal string _then_ we invoke the logic for field.