### PR TITLE
feat: add validation for selector syntax

### DIFF
--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -77,6 +77,12 @@ export type NamespaceSet = Record<string, FunctionSet | undefined>
 
 const global: FunctionSet = {}
 
+global.anywhere = async function anywhere() {
+  throw new Error('not implemented')
+}
+
+global.anywhere.arity = 1
+
 global.coalesce = async function coalesce(args, scope, execute) {
   for (const arg of args) {
     const value = await execute(arg, scope)

--- a/src/markProcessor.ts
+++ b/src/markProcessor.ts
@@ -82,6 +82,10 @@ export class MarkProcessor {
     this.index += 1
   }
 
+  unshift(): void {
+    this.index -= 1
+  }
+
   process<T>(visitor: MarkVisitor<T>): T {
     const mark = this.marks[this.index]
     this.shift()

--- a/src/markProcessor.ts
+++ b/src/markProcessor.ts
@@ -82,10 +82,6 @@ export class MarkProcessor {
     this.index += 1
   }
 
-  unshift(): void {
-    this.index -= 1
-  }
-
   process<T>(visitor: MarkVisitor<T>): T {
     const mark = this.marks[this.index]
     this.shift()

--- a/src/nodeTypes.ts
+++ b/src/nodeTypes.ts
@@ -37,6 +37,7 @@ export type ExprNode =
   | PosNode
   | ProjectionNode
   | SelectNode
+  | SelectorNode
   | SliceNode
   | ThisNode
   | TupleNode
@@ -207,6 +208,10 @@ export interface SelectNode extends BaseNode {
   type: 'Select'
   alternatives: SelectAlternativeNode[]
   fallback?: ExprNode
+}
+
+export interface SelectorNode extends BaseNode {
+  type: 'Selector'
 }
 
 export interface ThisNode extends BaseNode {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -363,7 +363,6 @@ const EXPR_BUILDER: MarkVisitor<NodeTypes.ExprNode> = {
         // being used. We expect the null valued arg to throw an error at evaluation time.
         p.process(SELECTOR_BUILDER)
         args.push({type: 'Selector'})
-        break
       } else {
         args.push(p.process(EXPR_BUILDER))
       }
@@ -778,9 +777,8 @@ const SELECTOR_BUILDER: MarkVisitor<null> = {
     throw new Error('Invalid selector syntax')
   },
 
-  func_call(p) {
-    p.unshift()
-    const func = p.process(EXPR_BUILDER) as NodeTypes.FuncCallNode
+  func_call(p, mark) {
+    const func = EXPR_BUILDER.func_call(p, mark) as NodeTypes.FuncCallNode
     if (func.name === 'anywhere' && func.args.length === 1) return null
 
     throw new Error('Invalid selector syntax')

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -59,12 +59,13 @@ t.test('Selector validation', async (t) => {
       'diff::changedAny({}, {}, foo.bar.baz)',
       'diff::changedAny({}, {}, foo[])',
       'diff::changedAny({}, {}, foo.bar[baz == 1])',
+      'diff::changedAny({}, {}, (foo))',
       'diff::changedAny({}, {}, anywhere(foo))',
     ]
 
-    queries.forEach((query) => {
+    for (const query of queries) {
       t.doesNotThrow(() => parse(query))
-    })
+    }
   })
 
   t.test('fails with invalid selectors', async (t) => {
@@ -72,28 +73,32 @@ t.test('Selector validation', async (t) => {
       'diff::changedAny({}, {}, "foo")',
       'diff::changedAny({}, {}, 1 + 2)',
       'diff::changedAny({}, {}, 5)',
-      'diff::changedAny({}, {}, (foo, bar))', // BUG: fails because we don't support tuples yet
-      'diff::changedAny({}, {}, (foo))', // BUG: fails because we don't support groups yet
+      'diff::changedAny({}, {}, (foo, bar))', // BUG: fails because we don't support tuples inside traversals yet
     ]
 
-    queries.forEach((query) => {
+    for (const query of queries) {
       try {
         parse(query)
       } catch (error: any) {
         t.same(error.message, 'Invalid selector syntax')
       }
-    })
+    }
   })
 
-  // BUG: the below case throws a syntax error because we don't support the syntax *yet*.
-  // This is a valid selector according to the spec, but not according to our implementation.
+  // BUG: the below cases throw syntax errors because we don't support their syntax *yet*.
+  // These are valid selectors according to the spec, but not according to our implementation.
   t.test('fails due to syntax error', async (t) => {
-    const query = 'diff::changedAny({}, {}, a[].(foo, bar).b)'
+    const queries = [
+      'diff::changedAny({}, {}, a.(foo).bar)',
+      'diff::changedAny({}, {}, a[].(foo, bar).b)',
+    ]
 
-    try {
-      parse(query)
-    } catch (error: any) {
-      t.match(error.message, 'Syntax error in GROQ query at position')
+    for (const query of queries) {
+      try {
+        parse(query)
+      } catch (error: any) {
+        t.match(error.message, 'Syntax error in GROQ query at position')
+      }
     }
   })
 })


### PR DESCRIPTION
[The GROQ spec](https://sanity-io.github.io/GROQ/draft/#sec-Selector) requires support for selector validation. This has yet to be added to `groq-js`. Selector validation is a pre-requisite to supporting the `diff` and `delta` extensions in `groq-js`.

Note that full selector syntax isn't available yet, we need to add support for tuples and groups when parsing traversals.

# Changes
* Add a `SELECTOR_BUILDER` to the parser to handle selector validation
* Add relevant unit tests