### PR TITLE
Fix build error related to selectors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,4 @@ jobs:
       - run: npm test
         env:
           CI: true
+      - run: npm run build

--- a/src/evaluator/evaluate.ts
+++ b/src/evaluator/evaluate.ts
@@ -53,6 +53,12 @@ const EXECUTORS: ExecutorMap = {
     return scope.value
   },
 
+  Selector() {
+    // These should be evaluated separely using a different evaluator.
+    // At the mooment we haven't implemented this.
+    throw new Error('Selectors can not be evaluated')
+  },
+
   Everything(_, scope) {
     return scope.source
   },


### PR DESCRIPTION
The build failed locally for me due to this missing evaluator.

Also added `npm run build` to the CI to ensure that we don't break the build.