### PR TITLE
fix: ensure 'default' export path is specified last 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/1.esm.mjs",
-        "types": "./dist/1.esm.d.ts"
+        "types": "./dist/1.esm.d.ts",
+        "default": "./dist/1.esm.mjs"
       },
       "require": {
-        "default": "./dist/1.umd.cjs",
-        "types": "./dist/1.umd.d.ts"
+        "types": "./dist/1.umd.d.ts",
+        "default": "./dist/1.umd.cjs"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
I was testing the new functionality inside another project (GROQ Arcade). The project wouldn't build and was erroring at runtime. It turns out Webpack is _very_ fussy about certain things, like whether the 'default' for exports is last in the list or not.

Changing the order fixes the issue. As far as I can tell this shouldn't negatively impact other builds/projects, so I think we should include the change in `main` and a new release candidate.
