### PR TITLE
fix: build errors on esm.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "require": {
         "types": "./dist/1.umd.d.ts",
         "default": "./dist/1.umd.cjs"
-      }
+      },
+      "default": "./dist/1.umd.cjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
The runtime support for `groq-js` is really [good](https://groq-runtimes-dashboard.sanity.build/).

Except in esm.sh, a popular ESM CDN used a lot by Deno folks:
```js
const {parse} = await import('https://esm.sh/groq-js')
// throws error:
// VM1039:1          GET https://esm.sh/groq-js@1.1.0 net::ERR_ABORTED 500
// (anonymous) @ VM1039:1
// Uncaught TypeError: Failed to fetch dynamically imported module: https://esm.sh/groq-js
```

Opening the [ESM url](https://esm.sh/groq-js@1.1.0) directly gives a more helpful error:
```js
/* esm.sh - error */
throw new Error("[esm.sh] " + "parseCJSModuleExports: Package path . is not exported from package /tmp/esm-build-215895dbb9a524568745e07124b861740c47353e-565f8556/node_modules/groq-js (see exports field in /tmp/esm-build-215895dbb9a524568745e07124b861740c47353e-565f8556/node_modules/groq-js/package.json)");
export default null;
```

This PR should fix that error and make esm.sh and other similar build tooling happy 😌 

[Always providing a "default" condition is the recommended best practice by the Node.js folks.](https://nodejs.org/api/packages.html#:~:text=When%20using%20environment%20branches%2C%20always%20include)