### PR TITLE
chore: add failing repro test case

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -37,6 +37,18 @@ t.test('Basic parsing', async (t) => {
     const tree = parse(query)
     t.matchSnapshot(tree)
   })
+
+  t.test('Complex query', async (t) => {
+    const query = `count(array::unique(
+      *[_type == 'page']{"_id": select(
+        _id in path("drafts.**") => _id,
+        "drafts." + _id
+      )}._id
+    ))`
+
+    const tree = parse(query)
+    t.matchSnapshot(tree)
+  })
 })
 
 t.test('Error reporting', async (t) => {


### PR DESCRIPTION
Running this query on Content Lake works fine:
```groq
count(array::unique(
  *[_type == 'page']{"_id": select(
    _id in path("drafts.**") => _id,
    "drafts." + _id
  )}._id
))
```

But creates a parse error in `groq-js`, attached a repro test case in this PR.