### PR TITLE
feat: add introspection utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "groq-js",
-  "version": "1.1.7",
+  "version": "1.2.0-introspect.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "groq-js",
-      "version": "1.1.7",
+      "version": "1.2.0-introspect.5",
       "license": "MIT",
       "devDependencies": {
         "@sanity/pkg-utils": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groq-js",
-  "version": "1.1.7",
+  "version": "1.2.0-introspect.5",
   "keywords": [
     "sanity",
     "json",

--- a/src/1.ts
+++ b/src/1.ts
@@ -3,6 +3,7 @@ export type {GroqFunction, GroqFunctionArg, GroqPipeFunction} from './evaluator/
 export type {Scope} from './evaluator/scope'
 export type {EvaluateOptions} from './evaluator/types'
 export type {Context, Executor} from './evaluator/types'
+export * from './introspection'
 export * from './nodeTypes'
 export {parse} from './parser'
 export type {ParseOptions} from './types'

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -1,0 +1,9 @@
+// Utilities for enabling introspection on query results
+
+import type {GroqType} from './values/types'
+
+export const introspectGroqType = Symbol('introspectGroqType')
+
+export interface IntrospectableGroqType {
+  [introspectGroqType]: GroqType
+}

--- a/src/values/utils.ts
+++ b/src/values/utils.ts
@@ -1,3 +1,4 @@
+import {introspectGroqType} from '../introspection'
 import {formatRFC3339, parseRFC3339} from './dateHelpers'
 import {Path} from './Path'
 import {StreamValue} from './StreamValue'
@@ -121,6 +122,11 @@ export function fromJS(val: any): Value {
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getType(data: any): GroqType {
+  // Allow overriding the type during introspection
+  if (typeof data == 'object' && data !== null && introspectGroqType in data) {
+    return data[introspectGroqType]
+  }
+
   if (data === null || typeof data === 'undefined') {
     return 'null'
   }


### PR DESCRIPTION
Highly experimental, not ready for review it's just surfaced here for transparency so the team is aware of where the code published to `npm i groq-js@introspection` is coming from.

It's being used to explore a source mapping concept in `groqz`.

The base is set to `pkg-utils` since it's the branch origin and using `main` would obfuscate the diff by showing tons of unrelated changes.