### PR TITLE
feat(performance): support for Map as dataset

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,6 +35,42 @@ The function will throw `GroqSyntaxError` if there's a syntax error in the query
 
 ## `evaluate`
 
+`evaluate` accepts a node returned by [`parse`](#parse) and evaluates the query. Example:
+
+```typescript
+let tree = parse('*[_type == "user"]{name}')
+
+let dataset = [
+  {_type: 'user', name: 'Michael'},
+  {_type: 'company', name: 'Bluth Company'},
+]
+
+// Evaluate a tree against a dataset
+let value = await evaluate(tree, {dataset})
+```
+
+`evaluate` accepts the `dataset` parameter in the following formats:
+
+**List of documents**
+
+```typescript
+let dataset = [
+  {_type: 'user', name: 'Michael'},
+  {_type: 'company', name: 'Bluth Company'},
+]
+```
+
+**ID-Document Map**
+
+```typescript
+let dataset = new Map([
+  ['abc123', {_id: 'abc123', _type: 'user', name: 'Michael'}],
+  ['def456', {_id: 'def456', _type: 'company', name: 'Bluth Company'},
+])
+```
+
+Other options:
+
 ```typescript
 interface EvaluateOptions {
   // The value that will be available as `@` in GROQ.
@@ -67,5 +103,3 @@ interface EvaluateOptions {
 
 declare async function evaluate(node: ExprNode, options: EvaluateOptions = {})
 ```
-
-`evaluate` accepts a node returned by [`parse`](#parse) and evaluates the query.

--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -96,7 +96,7 @@ global.coalesce = async function coalesce(args, scope, execute) {
 
 global.count = async function count(args, scope, execute) {
   const inner = await execute(args[0], scope)
-  if (!inner.isArray()) {
+  if (!inner.isArray() && !inner.isMap()) {
     return NULL_VALUE
   }
 

--- a/src/values/StreamValue.ts
+++ b/src/values/StreamValue.ts
@@ -19,6 +19,11 @@ export class StreamValue {
     return true
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  isMap(): boolean {
+    return true
+  }
+
   async get(): Promise<any> {
     const result = []
     for await (const value of this) {

--- a/src/values/types.ts
+++ b/src/values/types.ts
@@ -11,6 +11,7 @@ export type GroqType =
   | 'number'
   | 'string'
   | 'array'
+  | 'map'
   | 'object'
   | 'path'
   | 'datetime'
@@ -28,6 +29,7 @@ export type DateTimeValue = StaticValue<DateTime, 'datetime'>
 export type PathValue = StaticValue<Path, 'path'>
 export type ObjectValue = StaticValue<Record<string, unknown>, 'object'>
 export type ArrayValue = StaticValue<unknown[], 'array'>
+export type MapValue = StaticValue<Map<string, Value>, 'map'>
 
 export type AnyStaticValue =
   | StringValue
@@ -37,4 +39,5 @@ export type AnyStaticValue =
   | DateTimeValue
   | ObjectValue
   | ArrayValue
+  | MapValue
   | PathValue

--- a/src/values/utils.ts
+++ b/src/values/utils.ts
@@ -16,6 +16,10 @@ export class StaticValue<P, T extends GroqType> {
     return this.type === 'array'
   }
 
+  isMap(): boolean {
+    return this.type === 'map'
+  }
+
   // eslint-disable-next-line require-await
   async get(): Promise<any> {
     return this.data
@@ -29,6 +33,16 @@ export class StaticValue<P, T extends GroqType> {
         }
       })(this.data)
     }
+
+    if (this.data instanceof Map) {
+      return (function* (data) {
+        // This can be simplified when using es2015 target
+        for (const [id, value] of Array.from(data.entries())) {
+          yield fromJS(value)
+        }
+      })(this.data)
+    }
+
     throw new Error(`Cannot iterate over: ${this.type}`)
   }
 }
@@ -132,6 +146,9 @@ export function getType(data: any): GroqType {
   }
   if (data instanceof DateTime) {
     return 'datetime'
+  }
+  if (data instanceof Map) {
+    return 'map'
   }
   return typeof data as GroqType
 }

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -142,12 +142,12 @@ t.test('Basic parsing', async (t) => {
       ]
       const query = `count(*)`
       const tree = parse(query)
-  
+
       const value = await evaluate(tree, {dataset})
       const data = await value.get()
       t.same(data, 3)
     })
-  
+
     t.test('Count function with map dataset', async (t) => {
       const dataset = new Map([
         ['a1', {_id: 'a1', _type: 'product', name: 'T-shirt'}],
@@ -156,12 +156,12 @@ t.test('Basic parsing', async (t) => {
       ])
       const query = `count(*)`
       const tree = parse(query)
-  
+
       const value = await evaluate(tree, {dataset})
       const data = await value.get()
       t.same(data, 3)
     })
-  });
+  })
 
   t.test('Non-array documents', async (t) => {
     const dataset = {data: [{person: {_ref: 'b'}}]}

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -133,6 +133,36 @@ t.test('Basic parsing', async (t) => {
     ])
   })
 
+  t.test('Count function', async (t) => {
+    t.test('Count function with array dataset', async (t) => {
+      const dataset = [
+        {_type: 'product', name: 'T-shirt'},
+        {_type: 'product', name: 'Pants'},
+        {_type: 'user', name: 'Bob'},
+      ]
+      const query = `count(*)`
+      const tree = parse(query)
+  
+      const value = await evaluate(tree, {dataset})
+      const data = await value.get()
+      t.same(data, 3)
+    })
+  
+    t.test('Count function with map dataset', async (t) => {
+      const dataset = new Map([
+        ['a1', {_id: 'a1', _type: 'product', name: 'T-shirt'}],
+        ['b2', {_id: 'b2', _type: 'product', name: 'Pants'}],
+        ['c3', {_id: 'c3', _type: 'user', name: 'Bob'}],
+      ])
+      const query = `count(*)`
+      const tree = parse(query)
+  
+      const value = await evaluate(tree, {dataset})
+      const data = await value.get()
+      t.same(data, 3)
+    })
+  });
+
   t.test('Non-array documents', async (t) => {
     const dataset = {data: [{person: {_ref: 'b'}}]}
 


### PR DESCRIPTION
As the [High performance GROQ](https://www.sanity.io/docs/high-performance-groq#1b743110f831) mentions, resolving references can be really slow when using a large dataset.
I ran into an issue where querying a list of documents can result in ~3200ms execution time. This query just queries documents and resolves one reference in each document using the `->` operator, like:

```groq
*[_type == "book"] {
  title,
  "author": author->name
}
```

I made some debugging and I noticed that the majority of the time is spent in the `Deref` function when resolving references:
```ts
  async Deref({base}, scope, execute) {
    // ...

    const id = value.data._ref

    if (typeof id !== 'string') {
      return NULL_VALUE
    }

    // ⬇️ HERE ⬇️
    for await (const doc of scope.source) {
      if (doc.type === 'object' && id === doc.data._id) {
        return doc
    }

    return NULL_VALUE
  },
```

As the current implementation iterates over the entire dataset when resolving references, this will be exponentially slower when increasing the number of documents in the dataset.

I was thinking of simply indexing the documents using their `_id`s with a simple Map (`Map<ID, Document>`), so resolving references can be way faster than iterating over the whole dataset.

I'm not 100% sure what is the best way to add this feature, I was thinking of:
A) supporting a `Map<ID, Document>` as the value of the `dataset` parameter
B) adding an extra option like `indexById: Boolean` to `evaluate` which would transform the current `dataset: Array<Document>` to `dataset: Map<ID, Document>` before actually doing the evaluation

I ended up doing A) in this PR, and tested that slow query which I mentioned at the beginning with these changes, which got ~25x faster - from ~3200ms to ~125ms.

Let me know what you think!