### PR TITLE
Adding option to provide a custom dereference function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /.nyc_output
 /dist
 .DS_Store
+.history

--- a/src/1.ts
+++ b/src/1.ts
@@ -1,8 +1,13 @@
 export {evaluate} from './evaluator'
 export type {GroqFunction, GroqFunctionArg, GroqPipeFunction} from './evaluator/functions'
 export type {Scope} from './evaluator/scope'
-export type {EvaluateOptions} from './evaluator/types'
-export type {Context, Executor} from './evaluator/types'
+export type {
+  Context,
+  DereferenceFunction,
+  Document,
+  EvaluateOptions,
+  Executor,
+} from './evaluator/types'
 export * from './nodeTypes'
 export {parse} from './parser'
 export type {ParseOptions} from './types'

--- a/src/evaluator/evaluate.ts
+++ b/src/evaluator/evaluate.ts
@@ -253,6 +253,10 @@ const EXECUTORS: ExecutorMap = {
       return NULL_VALUE
     }
 
+    if (scope.context.dereference) {
+      return fromJS(await scope.context.dereference({_ref: id}))
+    }
+
     for await (const doc of scope.source) {
       if (doc.type === 'object' && id === doc.data._id) {
         return doc
@@ -472,6 +476,7 @@ export function evaluateQuery(
       sanity: options.sanity,
       after: options.after ? fromJS(options.after) : null,
       before: options.before ? fromJS(options.before) : null,
+      dereference: options.dereference,
     },
     null
   )

--- a/src/evaluator/types.ts
+++ b/src/evaluator/types.ts
@@ -3,6 +3,12 @@ import {Value} from '../values'
 import {Scope} from './scope'
 
 export type Executor<N = ExprNode> = (node: N, scope: Scope) => Value | PromiseLike<Value>
+export type Document = {
+  _id?: string
+  _type?: string
+  [T: string]: unknown
+}
+export type DereferenceFunction = (obj: {_ref: string}) => PromiseLike<Document | null | undefined>
 
 export interface EvaluateOptions {
   // The value that will be available as `@` in GROQ.
@@ -31,6 +37,9 @@ export interface EvaluateOptions {
     projectId: string
     dataset: string
   }
+
+  // Custom function to resolve document references
+  dereference?: DereferenceFunction
 }
 
 export interface Context {
@@ -42,4 +51,5 @@ export interface Context {
     projectId: string
     dataset: string
   }
+  dereference?: DereferenceFunction
 }

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -282,4 +282,24 @@ t.test('Basic parsing', async (t) => {
     const data = await value.get()
     t.same(data, 'abcdef')
   })
+
+  t.test('Custom dereference function', async (t) => {
+    const dataset = [
+      {_id: 'a', name: 'Michael'},
+      {_id: 'b', name: 'George Michael', father: {_ref: 'a'}},
+    ]
+    const datasetAsMap = new Map(dataset.map((data) => [data._id, data]))
+
+    const query = `*[]{ name, "father": father->name }`
+    const tree = parse(query)
+    const value = await evaluate(tree, {
+      dataset,
+      dereference: ({_ref}) => Promise.resolve(datasetAsMap.get(_ref)),
+    })
+    const data = await value.get()
+    t.same(data, [
+      {name: 'Michael', father: null},
+      {name: 'George Michael', father: 'Michael'},
+    ])
+  })
 })

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,5 +1,3 @@
-import t from 'tap'
-
 export async function throwsWithMessage(
   t: Tap.Test,
   funcUnderTest: () => {},


### PR DESCRIPTION
Adding an optional `dereference` function to `evaluate` options as discussed in https://github.com/sanity-io/groq-js/pull/93

Some things I was wondering while working on this:
- Technically speaking we could return a document in this function which does not exist in the dataset at all. Is this something to address?
- Shall the `dereference` function receive the `dataset` (original or after `fromJS` transformation) as a second parameter, so it can be used when doing the lookup?
- We agreed to use `PromiseLike<Document | null>` as return value, but having this function as async isn't necessary needed. Shall we add support for sync return value as well?