### PR TITLE
Handle parenthesis directly inside filters

### DIFF
--- a/src/evaluator/constantEvaluate.ts
+++ b/src/evaluator/constantEvaluate.ts
@@ -6,6 +6,7 @@ import {Scope} from './scope'
 function canConstantEvaluate(node: ExprNode): boolean {
   switch (node.type) {
     case 'Group':
+      return canConstantEvaluate(node.base)
     case 'Value':
     case 'Parameter':
       return true

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -201,3 +201,7 @@ t.test('Delta-GROQ', async (t) => {
     })
   }
 })
+
+t.test('handles parenthesis inside filters (regression bug)', async (t) => {
+  t.doesNotThrow(() => parse('*[(_type == "foo")]'))
+})


### PR DESCRIPTION
In queries like *[(type == "book")] we didn't properly recurse to determine if it's possible constant evaluate the expression.