### PR TITLE
feat: export Path class

### DIFF
--- a/src/1.ts
+++ b/src/1.ts
@@ -20,11 +20,10 @@ export type {
   NullValue,
   NumberValue,
   ObjectValue,
-  Path,
   PathValue,
   StaticValue,
   StreamValue,
   StringValue,
   Value,
 } from './values'
-export {DateTime} from './values'
+export {DateTime, Path} from './values'


### PR DESCRIPTION
For similar reason as #151, I need the `Path` class exported for [`@sanity-typed/groq-js`](https://github.com/saiichihashimoto/sanity-typed/tree/main/packages/groq-js)