### PR TITLE
test(typeEvaluator): add more fine-grained tests

### DIFF
--- a/src/typeEvaluator/evaluateQueryType.ts
+++ b/src/typeEvaluator/evaluateQueryType.ts
@@ -58,7 +58,7 @@ const $debug = debug('typeEvaluator:evaluate::debug')
 $debug.log = console.log.bind(console) // eslint-disable-line no-console
 const $warn = debug('typeEvaluator:evaluate::warn')
 
-export function evaluateNodeType(ast: ExprNode, schema: Schema): TypeNode {
+export function typeEvaluate(ast: ExprNode, schema: Schema): TypeNode {
   const parsed = walk({
     node: ast,
     scope: createScope([], undefined, createContext(schema)),
@@ -87,7 +87,7 @@ export function evaluateQueryType(query: string, schema: Schema): TypeNode {
 
   const ast = parse(query)
   $debug('evaluateQueryType.ast %O', ast)
-  return evaluateNodeType(ast, schema)
+  return typeEvaluate(ast, schema)
 }
 
 function handleDerefNode(node: DerefNode, scope: Scope): TypeNode {

--- a/src/typeEvaluator/evaluateQueryType.ts
+++ b/src/typeEvaluator/evaluateQueryType.ts
@@ -94,7 +94,7 @@ function handleDerefNode(node: DerefNode, scope: Scope): TypeNode {
   $trace('deref.base %O', derferencedField)
 
   return mapOptional(derferencedField, (field) => {
-    if (field.type === 'null' || field.type === 'never' || field.type === 'unknown') {
+    if (field.type === 'null' || field.type === 'unknown') {
       return {type: 'null'} satisfies NullTypeNode
     }
 
@@ -433,7 +433,7 @@ function mapProjectionInScope(
       return mapProjectionInScope(base.of[0], scope, mapper)
     }
     const of = base.of
-      .filter((f) => f.type !== 'unknown' && f.type !== 'null' && f.type !== 'never')
+      .filter((f) => f.type !== 'unknown' && f.type !== 'null')
       .map((f) => mapOptional(f, (f) => mapProjectionInScope(f, scope, mapper)))
     return {
       type: 'union',
@@ -454,7 +454,7 @@ function handleProjectionNode(node: ProjectionNode, scope: Scope): TypeNode {
   $trace('projection.scope %O', scope.value)
 
   return mapOptional(base, (newBase) => {
-    if (newBase.type === 'unknown' || newBase.type === 'null' || newBase.type === 'never') {
+    if (newBase.type === 'unknown' || newBase.type === 'null') {
       return {type: 'null'}
     }
 
@@ -488,11 +488,8 @@ function handleFilterNode(node: FilterNode, scope: Scope): TypeNode {
       const resolved = resolveFilter(node.expr, createFilterScope(base, scope))
       $trace('filter.resolved %O', resolved)
 
-      if (resolved.type === 'never') {
-        return {type: 'never'}
-      }
       if (resolved.type === 'union' && resolved.of.length === 0) {
-        return {type: 'never'}
+        return {type: 'null'}
       }
       return resolved
     }),

--- a/src/typeEvaluator/evaluateQueryType.ts
+++ b/src/typeEvaluator/evaluateQueryType.ts
@@ -35,7 +35,6 @@ import {createContext, createScope, Scope} from './scope'
 import type {
   ArrayTypeNode,
   BooleanTypeNode,
-  ConcatenationTypeNode,
   Document,
   NullTypeNode,
   NumberTypeNode,
@@ -259,30 +258,14 @@ function handleOpCallNode(node: OpCallNode, scope: Scope): TypeNode {
       } satisfies BooleanTypeNode
     }
     case '+': {
-      if (
-        left.type === 'string' &&
-        right.type === 'string' &&
-        left.value !== undefined &&
-        right.value !== undefined
-      ) {
+      if (left.type === 'string' && right.type === 'string') {
         return {
           type: 'string',
-          value: left.value + right.value,
+          value:
+            left.value !== undefined && right.value !== undefined
+              ? left.value + right.value
+              : undefined,
         }
-      }
-
-      if (left.type === 'string') {
-        const rhs = right.type === 'concatenation' ? right.fields : [right]
-        return {
-          type: 'concatenation',
-          fields: [left, ...rhs],
-        } satisfies ConcatenationTypeNode
-      }
-      if (left.type === 'concatenation') {
-        return {
-          type: 'concatenation',
-          fields: [...left.fields, right],
-        } satisfies ConcatenationTypeNode
       }
 
       if (left.type === 'number' && right.type === 'number') {

--- a/src/typeEvaluator/evaluateQueryType.ts
+++ b/src/typeEvaluator/evaluateQueryType.ts
@@ -522,7 +522,7 @@ function mapFieldInScope(
   if (field.type === 'object') {
     return mapper(field)
   }
-  return {type: 'unknown'} satisfies UnknownTypeNode
+  return {type: 'null'}
 }
 
 export function handleAccessAttributeNode(node: AccessAttributeNode, scope: Scope): TypeNode {
@@ -542,7 +542,7 @@ export function handleAccessAttributeNode(node: AccessAttributeNode, scope: Scop
       $warn(
         `field "${node.name}" not found in ${base.type === 'document' ? `document "${base.name}"` : 'object'}`,
       )
-      return {type: 'unknown'} satisfies UnknownTypeNode
+      return {type: 'null'}
     }),
   )
 }
@@ -749,8 +749,7 @@ export function walk({node, scope}: {node: ExprNode; scope: Scope}): TypeNode {
     }
     case 'Parameter': {
       return {
-        type: 'parameter',
-        name: node.name,
+        type: 'unknown',
       }
     }
 
@@ -785,13 +784,10 @@ function walkAndIgnoreOptional({node, scope}: {node: ExprNode; scope: Scope}): T
 function evaluateEquality(left: TypeNode, right: TypeNode): boolean | undefined {
   $trace('opcall == %O', {left, right})
   if (left.type === 'unknown' || right.type === 'unknown') {
-    return false
+    return undefined
   }
   if (left.type === 'null' && right.type === 'null') {
     return true
-  }
-  if (left.type === 'parameter' || right.type === 'parameter') {
-    return undefined
   }
 
   if (

--- a/src/typeEvaluator/evaluateQueryType.ts
+++ b/src/typeEvaluator/evaluateQueryType.ts
@@ -447,9 +447,6 @@ function mapFieldInScope(
       of: field.of.map((subField) => mapFieldInScope(subField, scope, mapper)),
     }
   }
-  if (field.type === 'array') {
-    return mapFieldInScope(field.of, scope, mapper)
-  }
 
   if (field.type === 'reference') {
     const lookupField = scope.context.lookupType(field)
@@ -551,9 +548,9 @@ function handleParentNode(node: ParentNode, scope: Scope): TypeNode {
   for (let n = node.n; n > 0; n--) {
     newScope = newScope?.parent
   }
-  $trace('parent.scope %n %O', node.n, newScope)
+  $trace('parent.scope %d %O', node.n, newScope)
   if (newScope !== undefined) {
-    return {type: 'array', of: newScope.value}
+    return newScope.value
   }
   return {type: 'null'} satisfies NullTypeNode
 }

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -3,19 +3,41 @@ import {walk} from './evaluateQueryType'
 import {Scope} from './scope'
 import {NullTypeNode, TypeNode} from './types'
 
+function unionWithoutNull(unionTypeNode: TypeNode): TypeNode {
+  if (unionTypeNode.type === 'union') {
+    return {
+      type: 'union',
+      of: unionTypeNode.of.filter((type) => type.type !== 'null'),
+    }
+  }
+  return unionTypeNode
+}
+
 export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
   switch (`${node.namespace}.${node.name}`) {
     case 'global.defined': {
-      return {type: 'unknown'}
+      return {type: 'boolean'}
     }
     case 'global.coalesce': {
       if (node.args.length === 0) {
         return {type: 'null'} satisfies NullTypeNode
       }
+      const typeNodes: TypeNode[] = []
+      let canBeNull = true
+      for (const arg of node.args) {
+        const type = walk({node: arg, scope})
+        typeNodes.push(unionWithoutNull(type))
+        canBeNull =
+          type.type === 'null' || (type.type === 'union' && type.of.some((t) => t.type === 'null'))
+      }
+
+      if (canBeNull) {
+        typeNodes.push({type: 'null'} satisfies NullTypeNode)
+      }
 
       return {
         type: 'union',
-        of: node.args.map((arg) => walk({node: arg, scope})),
+        of: typeNodes,
       }
     }
     case 'pt.text': {

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -3,7 +3,6 @@ export type {
   ArrayTypeNode,
   BooleanTypeNode,
   Document,
-  NeverTypeNode,
   NullTypeNode,
   NumberTypeNode,
   ObjectKeyValue,

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -5,7 +5,7 @@ export type {
   Document,
   NullTypeNode,
   NumberTypeNode,
-  ObjectKeyValue,
+  ObjectAttribute as ObjectKeyValue,
   ObjectTypeNode,
   PrimitiveTypeNode,
   ReferenceTypeNode,

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -2,7 +2,6 @@ export {typeEvaluate as evaluateNodeType, evaluateQueryType} from './evaluateQue
 export type {
   ArrayTypeNode,
   BooleanTypeNode,
-  ConcatenationTypeNode,
   Document,
   NeverTypeNode,
   NullTypeNode,

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -7,7 +7,6 @@ export type {
   NumberTypeNode,
   ObjectKeyValue,
   ObjectTypeNode,
-  OptionalTypeNode,
   PrimitiveTypeNode,
   ReferenceTypeNode,
   Schema,
@@ -17,3 +16,33 @@ export type {
   UnionTypeNode,
   UnknownTypeNode,
 } from './types'
+
+// @internal
+export type {
+  AnyStaticValue,
+  ArrayValue,
+  BooleanValue,
+  Context,
+  DateTime,
+  DateTimeValue,
+  DereferenceFunction,
+  Document as EvalDocument,
+  Executor,
+  ExprNode,
+  GroqFunction,
+  GroqFunctionArg,
+  GroqPipeFunction,
+  GroqType,
+  NullValue,
+  NumberValue,
+  ObjectValue,
+  Path,
+  PathValue,
+  Scope,
+  StaticValue,
+  StreamValue,
+  StringValue,
+  Value,
+} from '../1'
+// @internal
+export * from '../nodeTypes'

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -1,4 +1,4 @@
-export {evaluateNodeType, evaluateQueryType} from './evaluateQueryType'
+export {typeEvaluate as evaluateNodeType, evaluateQueryType} from './evaluateQueryType'
 export type {
   ArrayTypeNode,
   BooleanTypeNode,

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -1,4 +1,4 @@
-export {evaluateQueryType} from './evaluateQueryType'
+export {evaluateNodeType, evaluateQueryType} from './evaluateQueryType'
 export type {
   ArrayTypeNode,
   BooleanTypeNode,

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -9,7 +9,6 @@ export type {
   ObjectKeyValue,
   ObjectTypeNode,
   OptionalTypeNode,
-  ParameterTypeNode,
   PrimitiveTypeNode,
   ReferenceTypeNode,
   Schema,

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -17,10 +17,6 @@ export function hashField(field: TypeNode): string | null {
       return `${field.type}:${field.to}`
     }
 
-    case 'optional': {
-      return `${field.type}:${hashField(field.value)}`
-    }
-
     case 'array': {
       return `${field.type}:${hashField(field.of)}`
     }
@@ -71,7 +67,6 @@ export function optimizeUnions(field: TypeNode): TypeNode {
       return optimizeUnions(field.of[0])
     }
 
-    let hasOptional = false
     // flatten union
     for (let idx = 0; field.of.length > idx; idx++) {
       const subField = field.of[idx]
@@ -81,21 +76,7 @@ export function optimizeUnions(field: TypeNode): TypeNode {
         continue
       }
 
-      if (subField.type === 'optional') {
-        field.of.splice(idx, 1, subField.value)
-        hasOptional = true
-        idx--
-        continue
-      }
-
       field.of[idx] = optimizeUnions(subField)
-    }
-
-    if (hasOptional) {
-      return {
-        type: 'optional',
-        value: field,
-      }
     }
 
     return field
@@ -114,11 +95,6 @@ export function optimizeUnions(field: TypeNode): TypeNode {
 
       field.fields[idx].value = optimizeUnions(field.fields[idx].value)
     }
-    return field
-  }
-
-  if (field.type === 'optional') {
-    field.value = optimizeUnions(field.value)
     return field
   }
 

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -14,10 +14,6 @@ export function hashField(field: TypeNode): string | null {
       return field.type
     }
 
-    case 'parameter': {
-      return `${field.type}:${field.name}`
-    }
-
     case 'reference': {
       return `${field.type}:${field.to}`
     }

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -22,7 +22,7 @@ export function hashField(field: TypeNode): string | null {
     }
 
     case 'object': {
-      return `${field.type}:${Object.entries(field.fields)
+      return `${field.type}:${Object.entries(field.attributes)
         .map(([key, value]) => `${key}:${hashField(value.value)}`)
         .join(',')}`
     }
@@ -88,12 +88,12 @@ export function optimizeUnions(field: TypeNode): TypeNode {
   }
 
   if (field.type === 'object') {
-    for (const idx in field.fields) {
-      if (!Object.hasOwn(field.fields, idx)) {
+    for (const idx in field.attributes) {
+      if (!Object.hasOwn(field.attributes, idx)) {
         continue
       }
 
-      field.fields[idx].value = optimizeUnions(field.fields[idx].value)
+      field.attributes[idx].value = optimizeUnions(field.attributes[idx].value)
     }
     return field
   }

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -26,10 +26,6 @@ export function hashField(field: TypeNode): string | null {
       return `${field.type}:${hashField(field.value)}`
     }
 
-    case 'concatenation': {
-      return `${field.type}:${field.fields.map(hashField).join(',')}`
-    }
-
     case 'array': {
       return `${field.type}:${hashField(field.of)}`
     }

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -9,8 +9,7 @@ export function hashField(field: TypeNode): string | null {
     }
 
     case 'null':
-    case 'unknown':
-    case 'never': {
+    case 'unknown': {
       return field.type
     }
 

--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -1,11 +1,14 @@
 import {TypeNode} from './types'
 
-export function hashField(field: TypeNode): string | null {
+export function hashField(field: TypeNode): string {
   switch (field.type) {
     case 'string':
     case 'number':
     case 'boolean': {
-      return `${field.type}:${field.value}`
+      if (field.value !== undefined) {
+        return `${field.type}:${field.value}`
+      }
+      return `${field.type}`
     }
 
     case 'null':
@@ -78,6 +81,14 @@ export function optimizeUnions(field: TypeNode): TypeNode {
 
       field.of[idx] = optimizeUnions(subField)
     }
+
+    const compare = new Intl.Collator('en').compare
+    field.of.sort((a, b) => {
+      if (a.type === 'null') {
+        return 1
+      }
+      return compare(hashField(a), hashField(b))
+    })
 
     return field
   }

--- a/src/typeEvaluator/satisfies.ts
+++ b/src/typeEvaluator/satisfies.ts
@@ -27,8 +27,6 @@ export function satisfies(type: TypeNode, value: unknown): boolean {
       return value === null || satisfies(type.value, value)
     case 'unknown':
       return true
-    case 'concatenation':
-      return typeof value === 'string'
     case 'object':
       if (typeof value !== 'object' || value === null) return false
       return type.fields.every(

--- a/src/typeEvaluator/satisfies.ts
+++ b/src/typeEvaluator/satisfies.ts
@@ -27,9 +27,9 @@ export function satisfies(type: TypeNode, value: unknown): boolean {
       return true
     case 'object':
       if (typeof value !== 'object' || value === null) return false
-      return type.fields.every(
-        ({key, value: fieldType}) =>
-          value.hasOwnProperty(key) && satisfies(fieldType, (value as any)[key]),
+      return Object.entries(type.attributes).every(
+        ([key, fieldType]) =>
+          value.hasOwnProperty(key) && satisfies(fieldType.value, (value as any)[key]),
       )
     default:
       throw new Error(`Unknown type="${type.type}"`)

--- a/src/typeEvaluator/satisfies.ts
+++ b/src/typeEvaluator/satisfies.ts
@@ -1,0 +1,41 @@
+import {TypeNode} from './types'
+
+/**
+ * `satifies` takes in a type and a JavaScript value and checks if the value is satisfied by the type.
+ */
+export function satisfies(type: TypeNode, value: unknown): boolean {
+  switch (type.type) {
+    case 'null':
+      return value === null
+    case 'boolean': {
+      if (type.value !== undefined) return value === type.value
+      return typeof value === 'boolean'
+    }
+    case 'number': {
+      if (type.value !== undefined) return value === type.value
+      return typeof value === 'number'
+    }
+    case 'string': {
+      if (type.value !== undefined) return value === type.value
+      return typeof value === 'string'
+    }
+    case 'array':
+      return Array.isArray(value) && value.every((item) => satisfies(type.of, item))
+    case 'union':
+      return type.of.some((other) => satisfies(other, value))
+    case 'optional':
+      return value === null || satisfies(type.value, value)
+    case 'unknown':
+      return true
+    case 'concatenation':
+      return typeof value === 'string'
+    case 'object':
+      if (typeof value !== 'object' || value === null) return false
+      return type.fields.every(
+        ({key, value: fieldType}) =>
+          value.hasOwnProperty(key) && satisfies(fieldType, (value as any)[key]),
+      )
+    default:
+      throw new Error(`Unknown type="${type.type}"`)
+  }
+}

--- a/src/typeEvaluator/satisfies.ts
+++ b/src/typeEvaluator/satisfies.ts
@@ -23,8 +23,6 @@ export function satisfies(type: TypeNode, value: unknown): boolean {
       return Array.isArray(value) && value.every((item) => satisfies(type.of, item))
     case 'union':
       return type.of.some((other) => satisfies(other, value))
-    case 'optional':
-      return value === null || satisfies(type.value, value)
     case 'unknown':
       return true
     case 'object':

--- a/src/typeEvaluator/scope.ts
+++ b/src/typeEvaluator/scope.ts
@@ -22,7 +22,7 @@ export function createContext(schema: Schema): Context {
           if (val.name === ref.to) {
             return {
               type: 'object',
-              fields: val.fields,
+              attributes: val.attributes,
             }
           }
         }

--- a/src/typeEvaluator/types.ts
+++ b/src/typeEvaluator/types.ts
@@ -40,6 +40,7 @@ export interface ObjectKeyValue<T extends TypeNode = TypeNode> {
   type: 'objectKeyValue'
   key: string
   value: T
+  optional?: boolean
 }
 
 export interface ReferenceTypeNode {
@@ -57,10 +58,6 @@ export interface ArrayTypeNode<T extends TypeNode = TypeNode> {
   type: 'array'
   of: T
 }
-export interface OptionalTypeNode<T extends TypeNode = TypeNode> {
-  type: 'optional'
-  value: T
-}
 
 export type UnknownTypeNode = {type: 'unknown'}
 
@@ -74,4 +71,3 @@ export type TypeNode =
   | UnionTypeNode
   | ReferenceTypeNode
   | UnknownTypeNode
-  | OptionalTypeNode

--- a/src/typeEvaluator/types.ts
+++ b/src/typeEvaluator/types.ts
@@ -1,7 +1,7 @@
 export interface Document {
   type: 'document'
   name: string
-  fields: ObjectKeyValue<TypeNode>[]
+  attributes: Record<string, ObjectAttribute>
 }
 
 export interface TypeDeclaration {
@@ -33,12 +33,11 @@ export interface NullTypeNode {
 
 export interface ObjectTypeNode<T extends TypeNode = TypeNode> {
   type: 'object'
-  fields: ObjectKeyValue<T>[]
+  attributes: Record<string, ObjectAttribute<T>>
 }
 
-export interface ObjectKeyValue<T extends TypeNode = TypeNode> {
-  type: 'objectKeyValue'
-  key: string
+export interface ObjectAttribute<T extends TypeNode = TypeNode> {
+  type: 'objectAttribute'
   value: T
   optional?: boolean
 }

--- a/src/typeEvaluator/types.ts
+++ b/src/typeEvaluator/types.ts
@@ -57,10 +57,6 @@ export interface ArrayTypeNode<T extends TypeNode = TypeNode> {
   type: 'array'
   of: T
 }
-export interface ConcatenationTypeNode {
-  type: 'concatenation'
-  fields: Array<TypeNode>
-}
 export interface OptionalTypeNode<T extends TypeNode = TypeNode> {
   type: 'optional'
   value: T
@@ -79,7 +75,6 @@ export type TypeNode =
   | ArrayTypeNode
   | UnionTypeNode
   | ReferenceTypeNode
-  | ConcatenationTypeNode
   | UnknownTypeNode
   | NeverTypeNode
   | OptionalTypeNode

--- a/src/typeEvaluator/types.ts
+++ b/src/typeEvaluator/types.ts
@@ -64,7 +64,6 @@ export interface OptionalTypeNode<T extends TypeNode = TypeNode> {
 
 export type UnknownTypeNode = {type: 'unknown'}
 export type NeverTypeNode = {type: 'never'}
-export type ParameterTypeNode = {type: 'parameter'; name: string}
 
 export type TypeNode =
   | ObjectTypeNode
@@ -78,4 +77,3 @@ export type TypeNode =
   | UnknownTypeNode
   | NeverTypeNode
   | OptionalTypeNode
-  | ParameterTypeNode

--- a/src/typeEvaluator/types.ts
+++ b/src/typeEvaluator/types.ts
@@ -63,7 +63,6 @@ export interface OptionalTypeNode<T extends TypeNode = TypeNode> {
 }
 
 export type UnknownTypeNode = {type: 'unknown'}
-export type NeverTypeNode = {type: 'never'}
 
 export type TypeNode =
   | ObjectTypeNode
@@ -75,5 +74,4 @@ export type TypeNode =
   | UnionTypeNode
   | ReferenceTypeNode
   | UnknownTypeNode
-  | NeverTypeNode
   | OptionalTypeNode

--- a/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
+++ b/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
@@ -107,136 +107,116 @@ Object {
 exports[`test/evaluateQueryType.test.ts TAP complex 2 > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "_id",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "_id": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "name",
-        "type": "objectKeyValue",
+      "authorFullName": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": undefined,
+        },
+      },
+      "collaborators": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "of": Array [
+              Object {
+                "attributes": Object {
+                  "_type": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                      "value": "author",
+                    },
+                  },
+                  "collaboratorPosts": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "of": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "name": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "attributes": Object {
+                  "_type": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                      "value": "ghost",
+                    },
+                  },
+                  "collaboratorPosts": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "of": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "name": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+            ],
+            "type": "union",
+          },
+          "type": "array",
+        },
+      },
+      "name": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "authorFullName",
-        "type": "objectKeyValue",
+      "relatedConcepts": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "fields": Array [
+          "of": Array [
             Object {
-              "type": "string",
+              "of": Object {
+                "to": "concept",
+                "type": "reference",
+              },
+              "type": "array",
             },
             Object {
-              "type": "string",
-              "value": " ",
-            },
-            Object {
-              "type": "string",
+              "type": "unknown",
             },
           ],
-          "type": "concatenation",
+          "type": "union",
         },
       },
-      Object {
-        "key": "slug",
-        "type": "objectKeyValue",
+      "slug": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "type": "optional",
-          "value": Object {
-            "type": "unknown",
-          },
+          "type": "null",
         },
       },
-      Object {
-        "key": "relatedConcepts",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
-          "value": Object {
-            "type": "unknown",
-          },
-        },
-      },
-      Object {
-        "key": "collaborators",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
-          "value": Object {
-            "of": Object {
-              "of": Array [
-                Object {
-                  "fields": Array [
-                    Object {
-                      "key": "_type",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                        "value": "author",
-                      },
-                    },
-                    Object {
-                      "key": "name",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "key": "collaboratorPosts",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "of": Object {
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                    },
-                  ],
-                  "type": "object",
-                },
-                Object {
-                  "fields": Array [
-                    Object {
-                      "key": "_type",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                        "value": "ghost",
-                      },
-                    },
-                    Object {
-                      "key": "name",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "key": "collaboratorPosts",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "of": Object {
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                    },
-                  ],
-                  "type": "object",
-                },
-              ],
-              "type": "union",
-            },
-            "type": "array",
-          },
-        },
-      },
-    ],
+    },
     "type": "object",
   },
   "type": "array",
@@ -246,239 +226,106 @@ Object {
 exports[`test/evaluateQueryType.test.ts TAP complex > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "_id",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "_id": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "_type",
-        "type": "objectKeyValue",
+      "_type": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
           "value": "post",
         },
       },
-      Object {
-        "key": "name",
-        "type": "objectKeyValue",
+      "allAuthorsOrGhosts": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "type": "string",
-        },
-      },
-      Object {
-        "key": "lastname",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
-          "value": Object {
-            "type": "string",
-          },
-        },
-      },
-      Object {
-        "key": "authorDetails",
-        "type": "objectKeyValue",
-        "value": Object {
-          "fields": Array [
-            Object {
-              "key": "_id",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "string",
-              },
-            },
-            Object {
-              "key": "_type",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "string",
-                "value": "author",
-              },
-            },
-            Object {
-              "key": "name",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "string",
-              },
-            },
-            Object {
-              "key": "firstname",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "string",
-              },
-            },
-            Object {
-              "key": "lastname",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "string",
-              },
-            },
-            Object {
-              "key": "object",
-              "type": "objectKeyValue",
-              "value": Object {
-                "fields": Array [
-                  Object {
-                    "key": "subfield",
-                    "type": "objectKeyValue",
-                    "value": Object {
-                      "type": "string",
-                    },
-                  },
-                ],
-                "type": "object",
-              },
-            },
-            Object {
-              "key": "optionalObject",
-              "type": "objectKeyValue",
-              "value": Object {
-                "type": "optional",
-                "value": Object {
-                  "fields": Array [
-                    Object {
-                      "key": "subfield",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-          ],
-          "type": "object",
-        },
-      },
-      Object {
-        "key": "slugerDetails",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
-          "value": Object {
-            "type": "null",
-          },
-        },
-      },
-      Object {
-        "key": "authorOrGhost",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
-          "value": Object {
+          "of": Object {
             "of": Array [
               Object {
-                "fields": Array [
-                  Object {
-                    "key": "_type",
-                    "type": "objectKeyValue",
+                "attributes": Object {
+                  "_type": Object {
+                    "type": "objectAttribute",
                     "value": Object {
                       "type": "string",
                       "value": "author",
                     },
                   },
-                  Object {
-                    "key": "name",
-                    "type": "objectKeyValue",
+                  "details": Object {
+                    "type": "objectAttribute",
                     "value": Object {
-                      "type": "string",
-                    },
-                  },
-                  Object {
-                    "key": "details",
-                    "type": "objectKeyValue",
-                    "value": Object {
-                      "fields": Array [
-                        Object {
-                          "key": "firstname",
-                          "type": "objectKeyValue",
+                      "attributes": Object {
+                        "firstname": Object {
+                          "type": "objectAttribute",
                           "value": Object {
                             "type": "string",
                           },
                         },
-                        Object {
-                          "key": "lastname",
-                          "type": "objectKeyValue",
+                        "lastname": Object {
+                          "type": "objectAttribute",
                           "value": Object {
                             "type": "string",
                           },
                         },
-                        Object {
-                          "key": "object",
-                          "type": "objectKeyValue",
+                        "object": Object {
+                          "type": "objectAttribute",
                           "value": Object {
-                            "fields": Array [
-                              Object {
-                                "key": "subfield",
-                                "type": "objectKeyValue",
+                            "attributes": Object {
+                              "subfield": Object {
+                                "type": "objectAttribute",
                                 "value": Object {
                                   "type": "string",
                                 },
                               },
-                            ],
+                            },
                             "type": "object",
                           },
                         },
-                        Object {
-                          "key": "optionalObject",
-                          "type": "objectKeyValue",
+                        "optionalObject": Object {
+                          "type": "objectAttribute",
                           "value": Object {
-                            "type": "optional",
-                            "value": Object {
-                              "fields": Array [
-                                Object {
-                                  "key": "subfield",
-                                  "type": "objectKeyValue",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
+                            "attributes": Object {
+                              "subfield": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
                                 },
-                              ],
-                              "type": "object",
+                              },
                             },
+                            "type": "object",
                           },
                         },
-                      ],
+                      },
                       "type": "object",
                     },
                   },
-                ],
+                  "name": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
                 "type": "object",
               },
               Object {
-                "fields": Array [
-                  Object {
-                    "key": "_type",
-                    "type": "objectKeyValue",
+                "attributes": Object {
+                  "_type": Object {
+                    "type": "objectAttribute",
                     "value": Object {
                       "type": "string",
                       "value": "ghost",
                     },
                   },
-                  Object {
-                    "key": "name",
-                    "type": "objectKeyValue",
+                  "details": Object {
+                    "type": "objectAttribute",
                     "value": Object {
-                      "type": "string",
-                    },
-                  },
-                  Object {
-                    "key": "details",
-                    "type": "objectKeyValue",
-                    "value": Object {
-                      "fields": Array [
-                        Object {
-                          "key": "concepts",
-                          "type": "objectKeyValue",
+                      "attributes": Object {
+                        "concepts": Object {
+                          "type": "objectAttribute",
                           "value": Object {
                             "of": Object {
                               "to": "concept",
@@ -487,152 +334,221 @@ Object {
                             "type": "array",
                           },
                         },
-                      ],
+                      },
                       "type": "object",
                     },
                   },
-                ],
+                  "name": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
                 "type": "object",
               },
             ],
             "type": "union",
           },
+          "type": "array",
         },
       },
-      Object {
-        "key": "allAuthorsOrGhosts",
-        "type": "objectKeyValue",
+      "authorDetails": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "type": "optional",
-          "value": Object {
-            "of": Object {
-              "of": Array [
-                Object {
-                  "fields": Array [
-                    Object {
-                      "key": "_type",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                        "value": "author",
-                      },
-                    },
-                    Object {
-                      "key": "name",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "key": "details",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "fields": Array [
-                          Object {
-                            "key": "firstname",
-                            "type": "objectKeyValue",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
-                          Object {
-                            "key": "lastname",
-                            "type": "objectKeyValue",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
-                          Object {
-                            "key": "object",
-                            "type": "objectKeyValue",
-                            "value": Object {
-                              "fields": Array [
-                                Object {
-                                  "key": "subfield",
-                                  "type": "objectKeyValue",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
-                                },
-                              ],
-                              "type": "object",
-                            },
-                          },
-                          Object {
-                            "key": "optionalObject",
-                            "type": "objectKeyValue",
-                            "value": Object {
-                              "type": "optional",
-                              "value": Object {
-                                "fields": Array [
-                                  Object {
-                                    "key": "subfield",
-                                    "type": "objectKeyValue",
-                                    "value": Object {
-                                      "type": "string",
-                                    },
-                                  },
-                                ],
-                                "type": "object",
-                              },
-                            },
-                          },
-                        ],
-                        "type": "object",
-                      },
-                    },
-                  ],
-                  "type": "object",
-                },
-                Object {
-                  "fields": Array [
-                    Object {
-                      "key": "_type",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                        "value": "ghost",
-                      },
-                    },
-                    Object {
-                      "key": "name",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "key": "details",
-                      "type": "objectKeyValue",
-                      "value": Object {
-                        "fields": Array [
-                          Object {
-                            "key": "concepts",
-                            "type": "objectKeyValue",
-                            "value": Object {
-                              "of": Object {
-                                "to": "concept",
-                                "type": "reference",
-                              },
-                              "type": "array",
-                            },
-                          },
-                        ],
-                        "type": "object",
-                      },
-                    },
-                  ],
-                  "type": "object",
-                },
-              ],
-              "type": "union",
+          "attributes": Object {
+            "_id": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
             },
-            "type": "array",
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "author",
+              },
+            },
+            "firstname": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "lastname": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "name": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "object": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "attributes": Object {
+                  "subfield": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+            },
+            "optionalObject": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "attributes": Object {
+                  "subfield": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+            },
           },
+          "type": "object",
         },
       },
-    ],
+      "authorOrGhost": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Array [
+            Object {
+              "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "author",
+                  },
+                },
+                "details": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "attributes": Object {
+                      "firstname": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                      "lastname": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                      "object": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "attributes": Object {
+                            "subfield": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      },
+                      "optionalObject": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "attributes": Object {
+                            "subfield": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "name": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            Object {
+              "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "ghost",
+                  },
+                },
+                "details": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "attributes": Object {
+                      "concepts": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "of": Object {
+                            "to": "concept",
+                            "type": "reference",
+                          },
+                          "type": "array",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "name": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+          ],
+          "type": "union",
+        },
+      },
+      "lastname": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "name": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "slugerDetails": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "null",
+        },
+      },
+    },
     "type": "object",
   },
   "type": "array",

--- a/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
+++ b/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
@@ -8,10 +8,31 @@
 exports[`test/evaluateQueryType.test.ts TAP coalesce only > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "name",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "maybe": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Array [
+            Object {
+              "attributes": Object {
+                "subfield": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            Object {
+              "type": "null",
+            },
+          ],
+          "type": "union",
+        },
+      },
+      "name": Object {
+        "type": "objectAttribute",
         "value": Object {
           "of": Array [
             Object {
@@ -25,31 +46,7 @@ Object {
           "type": "union",
         },
       },
-      Object {
-        "key": "maybe",
-        "type": "objectKeyValue",
-        "value": Object {
-          "of": Array [
-            Object {
-              "fields": Array [
-                Object {
-                  "key": "subfield",
-                  "type": "objectKeyValue",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
-              ],
-              "type": "object",
-            },
-            Object {
-              "type": "null",
-            },
-          ],
-          "type": "union",
-        },
-      },
-    ],
+    },
     "type": "object",
   },
   "type": "array",
@@ -60,37 +57,33 @@ exports[`test/evaluateQueryType.test.ts TAP coalesce with projection > must matc
 Object {
   "of": Array [
     Object {
-      "fields": Array [
-        Object {
-          "key": "_type",
-          "type": "objectKeyValue",
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
           "value": Object {
             "type": "string",
             "value": "author",
           },
         },
-        Object {
-          "key": "foo",
-          "type": "objectKeyValue",
+        "foo": Object {
+          "type": "objectAttribute",
           "value": Object {
             "of": Array [
               Object {
-                "fields": Array [
-                  Object {
-                    "key": "subfield",
-                    "type": "objectKeyValue",
-                    "value": Object {
-                      "type": "string",
-                    },
-                  },
-                  Object {
-                    "key": "ref",
-                    "type": "objectKeyValue",
+                "attributes": Object {
+                  "ref": Object {
+                    "type": "objectAttribute",
                     "value": Object {
                       "type": "null",
                     },
                   },
-                ],
+                  "subfield": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
                 "type": "object",
               },
               Object {
@@ -100,7 +93,7 @@ Object {
             "type": "union",
           },
         },
-      ],
+      },
       "type": "object",
     },
     Object {
@@ -649,77 +642,68 @@ Object {
 exports[`test/evaluateQueryType.test.ts TAP filter order doesnt matter > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "_id",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "_id": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "_type",
-        "type": "objectKeyValue",
+      "_type": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
           "value": "author",
         },
       },
-      Object {
-        "key": "name",
-        "type": "objectKeyValue",
+      "firstname": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "firstname",
-        "type": "objectKeyValue",
+      "lastname": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "lastname",
-        "type": "objectKeyValue",
+      "name": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "object",
-        "type": "objectKeyValue",
+      "object": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "fields": Array [
-            Object {
-              "key": "subfield",
-              "type": "objectKeyValue",
+          "attributes": Object {
+            "subfield": Object {
+              "type": "objectAttribute",
               "value": Object {
                 "type": "string",
               },
             },
-          ],
+          },
           "type": "object",
         },
       },
-      Object {
-        "key": "optionalObject",
+      "optionalObject": Object {
         "optional": true,
-        "type": "objectKeyValue",
+        "type": "objectAttribute",
         "value": Object {
-          "fields": Array [
-            Object {
-              "key": "subfield",
-              "type": "objectKeyValue",
+          "attributes": Object {
+            "subfield": Object {
+              "type": "objectAttribute",
               "value": Object {
                 "type": "string",
               },
             },
-          ],
+          },
           "type": "object",
         },
       },
-    ],
+    },
     "type": "object",
   },
   "type": "array",
@@ -748,53 +732,47 @@ Object {
 exports[`test/evaluateQueryType.test.ts TAP misc > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "group",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "andWithAttriute": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "boolean",
+          "value": true,
+        },
+      },
+      "group": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "number",
           "value": 35,
         },
       },
-      Object {
-        "key": "notBool",
-        "type": "objectKeyValue",
+      "notBool": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "boolean",
           "value": true,
         },
       },
-      Object {
-        "key": "notField",
-        "type": "objectKeyValue",
+      "notField": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "boolean",
         },
       },
-      Object {
-        "key": "unknownParent",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "null",
-        },
-      },
-      Object {
-        "key": "andWithAttriute",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "boolean",
-          "value": true,
-        },
-      },
-      Object {
-        "key": "pt",
-        "type": "objectKeyValue",
+      "pt": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-    ],
+      "unknownParent": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "null",
+        },
+      },
+    },
     "type": "object",
   },
   "type": "array",
@@ -804,32 +782,22 @@ Object {
 exports[`test/evaluateQueryType.test.ts TAP object references > must match snapshot 1`] = `
 Object {
   "of": Object {
-    "fields": Array [
-      Object {
-        "key": "_id",
-        "type": "objectKeyValue",
+    "attributes": Object {
+      "_id": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
         },
       },
-      Object {
-        "key": "_type",
-        "type": "objectKeyValue",
+      "_type": Object {
+        "type": "objectAttribute",
         "value": Object {
           "type": "string",
           "value": "ghost",
         },
       },
-      Object {
-        "key": "name",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "string",
-        },
-      },
-      Object {
-        "key": "concepts",
-        "type": "objectKeyValue",
+      "concepts": Object {
+        "type": "objectAttribute",
         "value": Object {
           "of": Object {
             "to": "concept",
@@ -838,37 +806,40 @@ Object {
           "type": "array",
         },
       },
-      Object {
-        "key": "enabledConcepts",
-        "type": "objectKeyValue",
+      "disabledConcepts": Object {
+        "type": "objectAttribute",
         "value": Object {
           "of": Object {
-            "fields": Array [
-              Object {
-                "key": "name",
-                "type": "objectKeyValue",
+            "to": "concept",
+            "type": "reference",
+          },
+          "type": "array",
+        },
+      },
+      "enabledConcepts": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "attributes": Object {
+              "name": Object {
+                "type": "objectAttribute",
                 "value": Object {
                   "type": "string",
                 },
               },
-            ],
+            },
             "type": "object",
           },
           "type": "array",
         },
       },
-      Object {
-        "key": "disabledConcepts",
-        "type": "objectKeyValue",
+      "name": Object {
+        "type": "objectAttribute",
         "value": Object {
-          "of": Object {
-            "to": "concept",
-            "type": "reference",
-          },
-          "type": "array",
+          "type": "string",
         },
       },
-    ],
+    },
     "type": "object",
   },
   "type": "array",
@@ -877,34 +848,31 @@ Object {
 
 exports[`test/evaluateQueryType.test.ts TAP with conditional splat > must match snapshot 1`] = `
 Object {
-  "fields": Array [
-    Object {
-      "key": "not match",
-      "type": "objectKeyValue",
+  "attributes": Object {
+    "not match": Object {
+      "type": "objectAttribute",
       "value": Object {
-        "fields": Array [
-          Object {
-            "key": "match",
-            "type": "objectKeyValue",
+        "attributes": Object {
+          "match": Object {
+            "type": "objectAttribute",
             "value": Object {
-              "fields": Array [
-                Object {
-                  "key": "foo",
-                  "type": "objectKeyValue",
+              "attributes": Object {
+                "foo": Object {
+                  "type": "objectAttribute",
                   "value": Object {
                     "type": "number",
                     "value": 1,
                   },
                 },
-              ],
+              },
               "type": "object",
             },
           },
-        ],
+        },
         "type": "object",
       },
     },
-  ],
+  },
   "type": "object",
 }
 `

--- a/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
+++ b/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
@@ -643,6 +643,12 @@ exports[`test/evaluateQueryType.test.ts TAP filter order doesnt matter > must ma
 Object {
   "of": Object {
     "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
       "_id": Object {
         "type": "objectAttribute",
         "value": Object {
@@ -654,6 +660,12 @@ Object {
         "value": Object {
           "type": "string",
           "value": "author",
+        },
+      },
+      "age": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "number",
         },
       },
       "firstname": Object {

--- a/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
+++ b/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
@@ -752,7 +752,7 @@ Object {
               "type": "string",
             },
             Object {
-              "type": "unknown",
+              "type": "null",
             },
           ],
           "type": "union",

--- a/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
+++ b/tap-snapshots/test/evaluateQueryType.test.ts.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/evaluateQueryType.test.ts TAP coalesce > must match snapshot 1`] = `
+exports[`test/evaluateQueryType.test.ts TAP coalesce only > must match snapshot 1`] = `
 Object {
   "of": Object {
     "fields": Array [
@@ -25,6 +25,30 @@ Object {
           "type": "union",
         },
       },
+      Object {
+        "key": "maybe",
+        "type": "objectKeyValue",
+        "value": Object {
+          "of": Array [
+            Object {
+              "fields": Array [
+                Object {
+                  "key": "subfield",
+                  "type": "objectKeyValue",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              ],
+              "type": "object",
+            },
+            Object {
+              "type": "null",
+            },
+          ],
+          "type": "union",
+        },
+      },
     ],
     "type": "object",
   },
@@ -34,46 +58,56 @@ Object {
 
 exports[`test/evaluateQueryType.test.ts TAP coalesce with projection > must match snapshot 1`] = `
 Object {
-  "type": "optional",
-  "value": Object {
-    "fields": Array [
-      Object {
-        "key": "_type",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "string",
-          "value": "author",
-        },
-      },
-      Object {
-        "key": "foo",
-        "type": "objectKeyValue",
-        "value": Object {
-          "type": "optional",
+  "of": Array [
+    Object {
+      "fields": Array [
+        Object {
+          "key": "_type",
+          "type": "objectKeyValue",
           "value": Object {
-            "fields": Array [
-              Object {
-                "key": "subfield",
-                "type": "objectKeyValue",
-                "value": Object {
-                  "type": "string",
-                },
-              },
-              Object {
-                "key": "ref",
-                "type": "objectKeyValue",
-                "value": Object {
-                  "type": "null",
-                },
-              },
-            ],
-            "type": "object",
+            "type": "string",
+            "value": "author",
           },
         },
-      },
-    ],
-    "type": "object",
-  },
+        Object {
+          "key": "foo",
+          "type": "objectKeyValue",
+          "value": Object {
+            "of": Array [
+              Object {
+                "fields": Array [
+                  Object {
+                    "key": "subfield",
+                    "type": "objectKeyValue",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                  Object {
+                    "key": "ref",
+                    "type": "objectKeyValue",
+                    "value": Object {
+                      "type": "null",
+                    },
+                  },
+                ],
+                "type": "object",
+              },
+              Object {
+                "type": "null",
+              },
+            ],
+            "type": "union",
+          },
+        },
+      ],
+      "type": "object",
+    },
+    Object {
+      "type": "null",
+    },
+  ],
+  "type": "union",
 }
 `
 
@@ -670,21 +704,19 @@ Object {
       },
       Object {
         "key": "optionalObject",
+        "optional": true,
         "type": "objectKeyValue",
         "value": Object {
-          "type": "optional",
-          "value": Object {
-            "fields": Array [
-              Object {
-                "key": "subfield",
-                "type": "objectKeyValue",
-                "value": Object {
-                  "type": "string",
-                },
+          "fields": Array [
+            Object {
+              "key": "subfield",
+              "type": "objectKeyValue",
+              "value": Object {
+                "type": "string",
               },
-            ],
-            "type": "object",
-          },
+            },
+          ],
+          "type": "object",
         },
       },
     ],
@@ -696,23 +728,20 @@ Object {
 
 exports[`test/evaluateQueryType.test.ts TAP flatmap > must match snapshot 1`] = `
 Object {
-  "type": "optional",
-  "value": Object {
-    "of": Object {
-      "of": Array [
-        Object {
-          "to": "author",
-          "type": "reference",
-        },
-        Object {
-          "to": "ghost",
-          "type": "reference",
-        },
-      ],
-      "type": "union",
-    },
-    "type": "array",
+  "of": Object {
+    "of": Array [
+      Object {
+        "to": "author",
+        "type": "reference",
+      },
+      Object {
+        "to": "ghost",
+        "type": "reference",
+      },
+    ],
+    "type": "union",
   },
+  "type": "array",
 }
 `
 
@@ -747,19 +776,11 @@ Object {
         "key": "unknownParent",
         "type": "objectKeyValue",
         "value": Object {
-          "of": Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "null",
-            },
-          ],
-          "type": "union",
+          "type": "null",
         },
       },
       Object {
-        "key": "and",
+        "key": "andWithAttriute",
         "type": "objectKeyValue",
         "value": Object {
           "type": "boolean",

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -158,6 +158,7 @@ function inArray(input: AnnotatedValue[]): AnnotatedValue[] {
  * We have four different categories. This is mainly here so that we can exclude.
  */
 enum Category {
+  /** primitives + unknown. */
   PRIMITIVES,
   /** Objects of primitives + unknown. */
   OBJECTS,
@@ -178,8 +179,8 @@ const objects1InArrays = inArray(objects1)
 // object values actually have different keys. This tests a bit more stuff.
 
 const valuesForCategories: AnnotatedValue[][][] = [
-  [primitives, objects0, arrays, objects0InArrays],
-  [primitives, objects1, arrays, objects1InArrays],
+  [primitivesWithUnknown, objects0, arrays, objects0InArrays],
+  [primitivesWithUnknown, objects1, arrays, objects1InArrays],
 ]
 
 const SCHEMA: [] = []

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -130,7 +130,7 @@ function inObject(input: AnnotatedValue[], name: string): AnnotatedValue[] {
       desc: `{${name}=${desc}}`,
       type: {
         type: 'object',
-        fields: [{type: 'objectKeyValue', key: name, value: type}],
+        attributes: {[name]: {type: 'objectAttribute', value: type}},
       },
     })),
   }))

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -3,7 +3,7 @@ import t from 'tap'
 
 import {evaluate} from '../src/evaluator'
 import {operators} from '../src/evaluator/operators'
-import {ExprNode} from '../src/nodeTypes'
+import {ExprNode, OpCall} from '../src/nodeTypes'
 import {TypeNode} from '../src/typeEvaluator'
 import {typeEvaluate, overrideTypeForNode} from '../src/typeEvaluator/evaluateQueryType'
 import {satisfies} from '../src/typeEvaluator/satisfies'
@@ -301,7 +301,8 @@ t.test('AccessAttribute missing', async (t) => {
   })
 })
 
-for (const op of Object.keys(operators)) {
+const ops = Object.keys(operators) as OpCall[]
+for (const op of ops) {
   t.test(`OpCall ${op}`, async (t) => {
     subtestBinary({
       t,

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -1,0 +1,310 @@
+/* eslint-disable max-depth */
+import t from 'tap'
+
+import {evaluate} from '../src/evaluator'
+import {operators} from '../src/evaluator/operators'
+import {ExprNode} from '../src/nodeTypes'
+import {TypeNode} from '../src/typeEvaluator'
+import {evaluateNodeType, overrideTypeForNode} from '../src/typeEvaluator/evaluateQueryType'
+import {satisfies} from '../src/typeEvaluator/satisfies'
+
+/**
+ * The following tests uses the following strategy:
+ *
+ * First we built a list of "annotated values". These are values we a list of
+ * possible types. For instance, for the value `1` we have the types `number`,
+ * `1` and `unknown`.
+ *
+ * With a given annotated value and one of the types we can then build an
+ * ExprNode:
+ *
+ * ```ts
+ * {
+ *   type: "OpCall",
+ *   op: "+",
+ *   left: {type: "Value", value: …},
+ *   right: {type: "Value", value: …},
+ * }
+ * ```
+ *
+ * We then do two things (in "parallel"):
+ *
+ * 1. We run the regular evaulator. This will return a concrete value.
+ * 2. We run the type evaluator, *but* we tweak the inner `Value`-nodes so that
+ *    they are being inferred to one of the annotated type.
+ *
+ * Example: if the annotated values were `1` (with type: `number`) and `2` (with
+ * type: `unknown`), then the evaluator will return 3. The type evaluator will
+ * then be executed such that we test that `OpCall` with `number` and `unknown`
+ * matches this.
+ *
+ * The nice thing here is that everything can be generated. From a small set of
+ * annotated values we can build up arrays and objects and test for
+ * combinations.
+ *
+ */
+
+/**
+ * A type with a description. Used so that your test cases gets nicer names.
+ */
+type DescribedType = {
+  desc: string
+  type: TypeNode
+}
+
+/**
+ * A value annotated with possible types it satisfies.
+ */
+type AnnotatedValue = {
+  /** The value. */
+  value: any
+  /** A list of types which satifies this value. */
+  types: DescribedType[]
+  /** A unique key representing the value. Used for caching purposes. */
+  key: string
+}
+
+/**
+ * List of primitive annotated values.
+ */
+const primitives: AnnotatedValue[] = [
+  {
+    key: 'null',
+    value: null,
+    types: [{desc: 'null', type: {type: 'null'}}],
+  },
+  {
+    key: '1',
+    value: 1,
+    types: [
+      {desc: '1', type: {type: 'number', value: 1}},
+      {desc: 'number', type: {type: 'number'}},
+    ],
+  },
+  {
+    key: 'hello',
+    value: 'hello',
+    types: [
+      {desc: 'hello', type: {type: 'string', value: 'hello'}},
+      {desc: 'string', type: {type: 'string'}},
+    ],
+  },
+  {
+    key: 'true',
+    value: true,
+    types: [
+      {desc: 'true', type: {type: 'boolean', value: true}},
+      {desc: 'boolean', type: {type: 'boolean'}},
+    ],
+  },
+  {
+    key: 'false',
+    value: false,
+    types: [
+      {desc: 'false', type: {type: 'boolean', value: false}},
+      {desc: 'boolean', type: {type: 'boolean'}},
+    ],
+  },
+]
+
+/**
+ * Adds `type: "unknown"` into each annotated value.
+ */
+function withUnknown(input: AnnotatedValue[]): AnnotatedValue[] {
+  return input.map(({key, value, types}) => ({
+    key,
+    value,
+    types: types.concat({desc: 'unknown', type: {type: 'unknown'}}),
+  }))
+}
+
+/**
+ * Places each annotated value into an object with the given name.
+ * E.g. if the value is `1` then the result value here is `{[name]: 1}`.
+ */
+function inObject(input: AnnotatedValue[], name: string): AnnotatedValue[] {
+  return input.map(({key, value, types}) => ({
+    key: `obj(${name}, ${key})`,
+    value: {[name]: value},
+    types: types.map(({desc, type}) => ({
+      desc: `{${name}=${desc}}`,
+      type: {
+        type: 'object',
+        fields: [{type: 'objectKeyValue', key: name, value: type}],
+      },
+    })),
+  }))
+}
+
+/**
+ * Places each annotated value into an array.
+ * E.g. if the value is `1` then the result value here is `[1]`.
+ */
+function inArray(input: AnnotatedValue[]): AnnotatedValue[] {
+  return input.map(({key, value, types}) => ({
+    key: `arr(${key})`,
+    value: [value],
+    types: types.map(({desc, type}) => ({
+      desc: `[${desc}]`,
+      type: {
+        type: 'array',
+        of: type,
+      },
+    })),
+  }))
+}
+
+/**
+ * We have four different categories. This is mainly here so that we can exclude.
+ */
+enum Category {
+  PRIMITIVES,
+  /** Objects of primitives + unknown. */
+  OBJECTS,
+  /** Arrays of primitives + unknown. */
+  ARRAYS,
+  /** Array of objects of primities. */
+  OBJECTS_IN_ARRAYS,
+}
+
+const primitivesWithUnknown = withUnknown(primitives)
+const objects0 = inObject(primitivesWithUnknown, 'i0')
+const objects1 = inObject(primitivesWithUnknown, 'i1')
+const arrays = inArray(primitivesWithUnknown)
+const objects0InArrays = inArray(objects0)
+const objects1InArrays = inArray(objects1)
+
+// For the tests where we need _two_ annotated values we make sure that the
+// object values actually have different keys. This tests a bit more stuff.
+
+const valuesForCategories: AnnotatedValue[][][] = [
+  [primitives, objects0, arrays, objects0InArrays],
+  [primitives, objects1, arrays, objects1InArrays],
+]
+
+const SCHEMA: [] = []
+
+const ALL_CATEGORIES = [
+  Category.PRIMITIVES,
+  Category.OBJECTS,
+  Category.ARRAYS,
+  Category.OBJECTS_IN_ARRAYS,
+]
+
+type CachedResult = {
+  params: ExprNode[]
+  node: ExprNode
+  result: Promise<any>
+}
+
+type Cacher = (annotatedValues: AnnotatedValue[]) => CachedResult
+
+/**
+ * Builds a cacher which
+ */
+const buildCacher = (build: (params: ExprNode[]) => ExprNode): Cacher => {
+  const cache: Record<string, CachedResult> = {}
+  return (annotatedValues) => {
+    const key = annotatedValues.map(({key}) => key).join(';')
+    if (!(key in cache)) {
+      const params = annotatedValues.map(({value}) => ({type: 'Value', value}) satisfies ExprNode)
+      const node = build(params)
+      const result = (async () => await (await evaluate(node)).get())()
+      cache[key] = {params, node, result}
+    }
+    return cache[key]
+  }
+}
+
+/**
+ * Generates subtests for a case where we need a single annotated value.
+ */
+function subtestUnary({
+  t,
+  build,
+  variants = ALL_CATEGORIES,
+}: {
+  t: Tap.Test
+  variants?: Category[]
+  build: (param: ExprNode) => ExprNode
+}) {
+  const getCachedResult = buildCacher((params) => build(params[0]))
+
+  for (const variant of variants) {
+    for (const annotatedValue of valuesForCategories[0][variant]) {
+      const cachedResult = getCachedResult([annotatedValue])
+      for (const {desc, type} of annotatedValue.types) {
+        t.test(desc, async (t) => {
+          overrideTypeForNode(cachedResult.params[0], type)
+          const resultType = evaluateNodeType(cachedResult.node, SCHEMA)
+          const result = await cachedResult.result
+          t.ok(satisfies(resultType, result), 'evaluation matches type', {result, resultType})
+        })
+      }
+    }
+  }
+}
+
+/**
+ * Generates subtests for a case where we need a two annotated values.
+ */
+function subtestBinary({
+  t,
+  build,
+  variants1 = ALL_CATEGORIES,
+  variants2 = ALL_CATEGORIES,
+}: {
+  t: Tap.Test
+  variants1?: Category[]
+  variants2?: Category[]
+  build: (param1: ExprNode, param2: ExprNode) => ExprNode
+}) {
+  const getCachedResult = buildCacher((params) => build(params[0], params[1]))
+
+  for (const variant1 of variants1) {
+    for (const annotatedValue1 of valuesForCategories[0][variant1]) {
+      for (const variant2 of variants2) {
+        for (const annotatedValue2 of valuesForCategories[1][variant2]) {
+          const cachedResult = getCachedResult([annotatedValue1, annotatedValue2])
+          for (const {desc: desc1, type: type1} of annotatedValue1.types) {
+            for (const {desc: desc2, type: type2} of annotatedValue2.types) {
+              t.test(`${desc1},${desc2}`, async (t) => {
+                overrideTypeForNode(cachedResult.params[0], type1)
+                overrideTypeForNode(cachedResult.params[1], type2)
+                const resultType = evaluateNodeType(cachedResult.node, SCHEMA)
+                const result = await cachedResult.result
+                t.ok(satisfies(resultType, result), 'evaluation should match type', {
+                  result,
+                  resultType,
+                })
+              })
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+t.test('AccessAttribute found', async (t) => {
+  subtestUnary({
+    t,
+    build: (param) => ({type: 'AccessAttribute', base: param, name: 'i0'}),
+  })
+})
+
+t.test('AccessAttribute missing', async (t) => {
+  subtestUnary({
+    t,
+    build: (param) => ({type: 'AccessAttribute', base: param, name: 'notFound'}),
+  })
+})
+
+for (const op of Object.keys(operators)) {
+  t.test(`OpCall ${op}`, async (t) => {
+    subtestBinary({
+      t,
+      build: (left, right) => ({type: 'OpCall', op, left, right}),
+    })
+  })
+}

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -5,7 +5,7 @@ import {evaluate} from '../src/evaluator'
 import {operators} from '../src/evaluator/operators'
 import {ExprNode} from '../src/nodeTypes'
 import {TypeNode} from '../src/typeEvaluator'
-import {evaluateNodeType, overrideTypeForNode} from '../src/typeEvaluator/evaluateQueryType'
+import {typeEvaluate, overrideTypeForNode} from '../src/typeEvaluator/evaluateQueryType'
 import {satisfies} from '../src/typeEvaluator/satisfies'
 
 /**
@@ -237,7 +237,7 @@ function subtestUnary({
       for (const {desc, type} of annotatedValue.types) {
         t.test(desc, async (t) => {
           overrideTypeForNode(cachedResult.params[0], type)
-          const resultType = evaluateNodeType(cachedResult.node, SCHEMA)
+          const resultType = typeEvaluate(cachedResult.node, SCHEMA)
           const result = await cachedResult.result
           t.ok(satisfies(resultType, result), 'evaluation matches type', {result, resultType})
         })
@@ -272,7 +272,7 @@ function subtestBinary({
               t.test(`${desc1},${desc2}`, async (t) => {
                 overrideTypeForNode(cachedResult.params[0], type1)
                 overrideTypeForNode(cachedResult.params[1], type2)
-                const evaluatedNodeType = evaluateNodeType(cachedResult.node, SCHEMA)
+                const evaluatedNodeType = typeEvaluate(cachedResult.node, SCHEMA)
                 const expectedValue = await cachedResult.result
                 t.ok(satisfies(evaluatedNodeType, expectedValue), 'evaluation should match type', {
                   expectedValue,

--- a/test/evaluateQueryNode.test.ts
+++ b/test/evaluateQueryNode.test.ts
@@ -200,7 +200,8 @@ type CachedResult = {
 type Cacher = (annotatedValues: AnnotatedValue[]) => CachedResult
 
 /**
- * Builds a cacher which
+ * Builds a "cacher" which takes in an annotated value and caches as much as possible.
+ * We use this to be able to speed up the tests since they often work on the same values.
  */
 const buildCacher = (build: (params: ExprNode[]) => ExprNode): Cacher => {
   const cache: Record<string, CachedResult> = {}
@@ -271,11 +272,11 @@ function subtestBinary({
               t.test(`${desc1},${desc2}`, async (t) => {
                 overrideTypeForNode(cachedResult.params[0], type1)
                 overrideTypeForNode(cachedResult.params[1], type2)
-                const resultType = evaluateNodeType(cachedResult.node, SCHEMA)
-                const result = await cachedResult.result
-                t.ok(satisfies(resultType, result), 'evaluation should match type', {
-                  result,
-                  resultType,
+                const evaluatedNodeType = evaluateNodeType(cachedResult.node, SCHEMA)
+                const expectedValue = await cachedResult.result
+                t.ok(satisfies(evaluatedNodeType, expectedValue), 'evaluation should match type', {
+                  expectedValue,
+                  evaluatedNodeType,
                 })
               })
             }

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -133,6 +133,12 @@ const authorDocument = {
         type: 'string',
       },
     },
+    age: {
+      type: 'objectAttribute',
+      value: {
+        type: 'number',
+      },
+    },
     object: {
       type: 'objectAttribute',
       value: {
@@ -567,7 +573,7 @@ t.test('values in projection', (t) => {
             "notEqualObject": 3 != {},
             "plus": 3 + 2,
             "plusStr": "3" + "2",
-            "plusVar": 3 + field,
+            "plusVar": 3 + age,
             "minus": 3 - 2,
             "mul": 3 * 3,
             "div": 100 / 5,
@@ -650,6 +656,7 @@ t.test('values in projection', (t) => {
           type: 'objectAttribute',
           value: {
             type: 'number',
+            value: undefined,
           },
         },
         minus: {

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -3,14 +3,13 @@ import t from 'tap'
 import {evaluateQueryType} from '../src/typeEvaluator/evaluateQueryType'
 import {
   ArrayTypeNode,
-  NeverTypeNode,
+  NullTypeNode,
   ObjectTypeNode,
   OptionalTypeNode,
   Schema,
   TypeNode,
   UnionTypeNode,
 } from '../src/typeEvaluator/types'
-import {satisfies} from '../src/typeEvaluator/satisfies'
 
 const schemas = [
   {
@@ -477,9 +476,9 @@ t.test('subfilter doesnt match', (t) => {
   t.strictSame(res, {
     type: 'array',
     of: {
-      type: 'never',
+      type: 'null',
     },
-  } satisfies ArrayTypeNode<NeverTypeNode>)
+  } satisfies ArrayTypeNode<NullTypeNode>)
 
   t.end()
 })
@@ -562,9 +561,9 @@ t.test('never', (t) => {
   t.strictSame(res, {
     type: 'array',
     of: {
-      type: 'never',
+      type: 'null',
     },
-  } satisfies ArrayTypeNode<NeverTypeNode>)
+  } satisfies ArrayTypeNode<NullTypeNode>)
 
   t.end()
 })

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -10,6 +10,7 @@ import {
   TypeNode,
   UnionTypeNode,
 } from '../src/typeEvaluator/types'
+import {satisfies} from '../src/typeEvaluator/satisfies'
 
 const schemas = [
   {
@@ -1188,7 +1189,7 @@ t.test('subquery', (t) => {
   t.end()
 })
 
-t.test('3 fields with concetnation', (t) => {
+t.test('string concetnation', (t) => {
   const query = `*[_type == "author"]{
             name,
             "fullName": firstname + " " + lastname,
@@ -1211,24 +1212,13 @@ t.test('3 fields with concetnation', (t) => {
           type: 'objectKeyValue',
           key: 'fullName',
           value: {
-            type: 'concatenation',
-            fields: [
-              {
-                type: 'string',
-              },
-              {
-                type: 'string',
-                value: ' ',
-              },
-              {
-                type: 'string',
-              },
-            ],
+            type: 'string',
+            value: undefined,
           },
         },
       ],
     },
-  })
+  } satisfies ArrayTypeNode<ObjectTypeNode>)
 
   t.end()
 })

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -420,7 +420,7 @@ t.test('in operator', (t) => {
     type: 'array',
     of: {
       type: 'union',
-      of: [findSchemaType('post'), findSchemaType('author')],
+      of: [findSchemaType('author'), findSchemaType('post')],
     },
   } satisfies ArrayTypeNode<UnionTypeNode>)
 
@@ -1183,7 +1183,7 @@ t.test('with select', (t) => {
               type: 'objectAttribute',
               value: {
                 type: 'string',
-                value: 'post',
+                value: 'author',
               },
             },
             authorName: {
@@ -1201,7 +1201,7 @@ t.test('with select', (t) => {
               type: 'objectAttribute',
               value: {
                 type: 'string',
-                value: 'author',
+                value: 'post',
               },
             },
             authorName: {
@@ -1240,7 +1240,7 @@ t.test('with select, not guaranteed & with fallback', (t) => {
               type: 'objectAttribute',
               value: {
                 type: 'string',
-                value: 'post',
+                value: 'author',
               },
             },
             something: {
@@ -1267,7 +1267,7 @@ t.test('with select, not guaranteed & with fallback', (t) => {
               type: 'objectAttribute',
               value: {
                 type: 'string',
-                value: 'author',
+                value: 'post',
               },
             },
             something: {

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -11,7 +11,6 @@ import {
   TypeNode,
   UnionTypeNode,
 } from '../src/typeEvaluator/types'
-import {satisfies} from '../src/typeEvaluator/satisfies'
 
 const postDocument = {
   type: 'document',
@@ -37,6 +36,13 @@ const postDocument = {
       },
     } satisfies ObjectAttribute,
     lastname: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+      optional: true,
+    } satisfies ObjectAttribute,
+    publishedAt: {
       type: 'objectAttribute',
       value: {
         type: 'string',
@@ -128,6 +134,12 @@ const authorDocument = {
       },
     },
     lastname: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+    },
+    _createdAt: {
       type: 'objectAttribute',
       value: {
         type: 'string',
@@ -820,6 +832,13 @@ t.test('deref with projection union', (t) => {
           },
           optional: true,
         },
+        publishedAt: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+          optional: true,
+        },
         author: {
           type: 'objectAttribute',
           value: {
@@ -1316,6 +1335,18 @@ t.test('with splat', (t) => {
           type: 'objectAttribute',
           value: {
             type: 'string',
+          },
+        },
+        _createdAt: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        age: {
+          type: 'objectAttribute',
+          value: {
+            type: 'number',
           },
         },
         object: {

--- a/test/evaluateQueryType.test.ts
+++ b/test/evaluateQueryType.test.ts
@@ -3,68 +3,83 @@ import t from 'tap'
 import {evaluateQueryType} from '../src/typeEvaluator/evaluateQueryType'
 import {
   ArrayTypeNode,
+  Document,
+  ObjectAttribute,
   ObjectTypeNode,
   Schema,
+  TypeDeclaration,
   TypeNode,
   UnionTypeNode,
 } from '../src/typeEvaluator/types'
+import {satisfies} from '../src/typeEvaluator/satisfies'
 
-const schemas = [
-  {
-    type: 'document',
-    name: 'post',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: '_id',
-        value: {
-          type: 'string',
-        },
+const postDocument = {
+  type: 'document',
+  name: 'post',
+  attributes: {
+    _id: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: '_type',
-        value: {
-          type: 'string',
-          value: 'post',
-        },
+    } satisfies ObjectAttribute,
+    _type: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: 'post',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'name',
-        value: {
-          type: 'string',
-        },
+    } satisfies ObjectAttribute,
+    name: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'lastname',
-        value: {
-          type: 'string',
-        },
-        optional: true,
+    } satisfies ObjectAttribute,
+    lastname: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'author',
-        value: {
-          type: 'reference',
-          to: 'author',
-        },
+      optional: true,
+    } satisfies ObjectAttribute,
+    author: {
+      type: 'objectAttribute',
+      value: {
+        type: 'reference',
+        to: 'author',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'sluger',
-        value: {
-          type: 'reference',
-          to: 'slug',
-        },
-        optional: true,
+    } satisfies ObjectAttribute,
+    sluger: {
+      type: 'objectAttribute',
+      value: {
+        type: 'reference',
+        to: 'slug',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'authorOrGhost',
-        value: {
+      optional: true,
+    } satisfies ObjectAttribute,
+    authorOrGhost: {
+      type: 'objectAttribute',
+      value: {
+        type: 'union',
+        of: [
+          {
+            type: 'reference',
+            to: 'author',
+          },
+          {
+            type: 'reference',
+            to: 'ghost',
+          },
+        ],
+      },
+      optional: true,
+    } satisfies ObjectAttribute,
+    allAuthorOrGhost: {
+      type: 'objectAttribute',
+      value: {
+        type: 'array',
+        of: {
           type: 'union',
           of: [
             {
@@ -77,269 +92,236 @@ const schemas = [
             },
           ],
         },
-        optional: true,
       },
-      {
-        type: 'objectKeyValue',
-        key: 'allAuthorOrGhost',
-        value: {
-          type: 'array',
-          of: {
-            type: 'union',
-            of: [
-              {
-                type: 'reference',
-                to: 'author',
-              },
-              {
-                type: 'reference',
-                to: 'ghost',
-              },
-            ],
-          },
-        },
-        optional: true,
-      },
-    ],
+      optional: true,
+    } satisfies ObjectAttribute,
   },
-  {
-    type: 'document',
-    name: 'author',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: '_id',
-        value: {
-          type: 'string',
-        },
+} satisfies Document
+
+const authorDocument = {
+  type: 'document',
+  name: 'author',
+  attributes: {
+    _id: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: '_type',
-        value: {
-          type: 'string',
-          value: 'author',
-        },
+    },
+    _type: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: 'author',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'name',
-        value: {
-          type: 'string',
-        },
+    },
+    name: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'firstname',
-        value: {
-          type: 'string',
-        },
+    },
+    firstname: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'lastname',
-        value: {
-          type: 'string',
-        },
+    },
+    lastname: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
       },
-      {
-        type: 'objectKeyValue',
-        key: 'object',
-        value: {
-          type: 'object',
-          fields: [
-            {
-              key: 'subfield',
-              type: 'objectKeyValue',
-              value: {
-                type: 'string',
-              },
+    },
+    object: {
+      type: 'objectAttribute',
+      value: {
+        type: 'object',
+        attributes: {
+          subfield: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
             },
-          ],
-        },
-      },
-      {
-        type: 'objectKeyValue',
-        key: 'optionalObject',
-        value: {
-          type: 'object',
-          fields: [
-            {
-              key: 'subfield',
-              type: 'objectKeyValue',
-              value: {
-                type: 'string',
-              },
-            },
-          ],
-        },
-        optional: true,
-      },
-    ],
-  },
-  {
-    type: 'document',
-    name: 'ghost',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: '_id',
-        value: {
-          type: 'string',
-        },
-      },
-      {
-        type: 'objectKeyValue',
-        key: '_type',
-        value: {
-          type: 'string',
-          value: 'ghost',
-        },
-      },
-      {
-        type: 'objectKeyValue',
-        key: 'name',
-        value: {
-          type: 'string',
-        },
-      },
-      {
-        type: 'objectKeyValue',
-        key: 'concepts',
-        value: {
-          type: 'array',
-          of: {
-            type: 'reference',
-            to: 'concept',
           },
         },
       },
-    ],
+    },
+    optionalObject: {
+      type: 'objectAttribute',
+      optional: true,
+      value: {
+        type: 'object',
+        attributes: {
+          subfield: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
   },
-  {
-    type: 'document',
-    name: 'namespace.one',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: '_type',
-        value: {
-          type: 'string',
-          value: 'namespace.one',
+} satisfies Document
+const ghostDocument = {
+  type: 'document',
+  name: 'ghost',
+  attributes: {
+    _id: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+    },
+    _type: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: 'ghost',
+      },
+    },
+    name: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+    },
+    concepts: {
+      type: 'objectAttribute',
+      value: {
+        type: 'array',
+        of: {
+          type: 'reference',
+          to: 'concept',
         },
       },
-      {
-        type: 'objectKeyValue',
-        key: 'name',
+    },
+  },
+} satisfies Document
+
+const namespaceOneDocument = {
+  type: 'document',
+  name: 'namespace.one',
+  attributes: {
+    _type: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: 'namespace.one',
+      },
+    } satisfies ObjectAttribute,
+    name: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+    } satisfies ObjectAttribute,
+    boolField: {
+      type: 'objectAttribute',
+      value: {
+        type: 'boolean',
+      },
+    } satisfies ObjectAttribute,
+  },
+} satisfies Document
+
+const namespaceTwoDocument = {
+  type: 'document',
+  name: 'namespace.two',
+  attributes: {
+    _type: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: 'namespace.two',
+      },
+    } satisfies ObjectAttribute,
+    name: {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+      },
+    } satisfies ObjectAttribute,
+  },
+} satisfies Document
+const conceptType = {
+  type: 'type',
+  name: 'concept',
+  value: {
+    type: 'object',
+    attributes: {
+      name: {
+        type: 'objectAttribute',
         value: {
           type: 'string',
         },
       },
-      {
-        type: 'objectKeyValue',
-        key: 'boolField',
+      enabled: {
+        type: 'objectAttribute',
         value: {
           type: 'boolean',
         },
       },
-    ],
-  },
-  {
-    type: 'document',
-    name: 'namespace.two',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: '_type',
+      posts: {
+        type: 'objectAttribute',
         value: {
-          type: 'string',
-          value: 'namespace.two',
+          type: 'array',
+          of: {
+            type: 'reference',
+            to: 'post',
+          },
         },
       },
-      {
-        type: 'objectKeyValue',
-        key: 'name',
+    },
+  },
+} satisfies TypeDeclaration
+const slugType = {
+  name: 'slug',
+  type: 'type',
+  value: {
+    type: 'object',
+    attributes: {
+      current: {
+        type: 'objectAttribute',
         value: {
           type: 'string',
         },
+        optional: true,
       },
-    ],
-  },
-  {
-    type: 'type',
-    name: 'concept',
-    value: {
-      type: 'object',
-      fields: [
-        {
-          key: 'name',
-          type: 'objectKeyValue',
-          value: {
-            type: 'string',
-          },
+      source: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
         },
-        {
-          key: 'enabled',
-          type: 'objectKeyValue',
-          value: {
-            type: 'boolean',
-          },
+        optional: true,
+      },
+      _type: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: 'slug',
         },
-        {
-          key: 'posts',
-          type: 'objectKeyValue',
-          value: {
-            type: 'array',
-            of: {
-              type: 'reference',
-              to: 'post',
-            },
-          },
+      },
+      _key: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
         },
-      ],
+        optional: true,
+      },
     },
   },
-  {
-    name: 'slug',
-    type: 'type',
-    value: {
-      type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'current',
-          value: {
-            type: 'string',
-          },
-          optional: true,
-        },
-        {
-          type: 'objectKeyValue',
-          key: 'source',
-          value: {
-            type: 'string',
-          },
-          optional: true,
-        },
-        {
-          type: 'objectKeyValue',
-          key: '_type',
-          value: {
-            type: 'string',
-            value: 'slug',
-          },
-        },
-        {
-          type: 'objectKeyValue',
-          key: '_key',
-          value: {
-            type: 'string',
-          },
-          optional: true,
-        },
-      ],
-    },
-  },
+} satisfies TypeDeclaration
+
+const schemas = [
+  postDocument,
+  authorDocument,
+  ghostDocument,
+  namespaceOneDocument,
+  namespaceTwoDocument,
+  conceptType,
+  slugType,
 ] satisfies Schema
 
 t.test('no projection', (t) => {
@@ -473,23 +455,21 @@ t.test('subfilter with projection', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          key: 'name',
-          type: 'objectKeyValue',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          key: '_type',
-          type: 'objectKeyValue',
+        _type: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
             value: 'namespace.one',
           },
         },
-      ],
+      },
     },
   } satisfies ArrayTypeNode<ObjectTypeNode>)
 
@@ -518,7 +498,7 @@ t.test('coerce reference', (t) => {
       type: 'reference',
       to: 'author',
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -562,17 +542,16 @@ t.test('simple', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          key: 'name',
-          type: 'objectKeyValue',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-      ],
+      },
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -603,129 +582,113 @@ t.test('values in projection', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'isAuthor',
+      attributes: {
+        isAuthor: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'greaterThan',
+        greaterThan: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'lessThan',
+        lessThan: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: false,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'greaterThanOrEq',
+        greaterThanOrEq: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'lessThanOrEq',
+        lessThanOrEq: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'notEqual',
+        notEqual: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'notEqualObject',
+        notEqualObject: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: true,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'plus',
+        plus: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 5,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'plusStr',
+        plusStr: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
             value: '32',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'plusVar',
+        plusVar: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'minus',
+        minus: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 1,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'mul',
+        mul: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 9,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'div',
+        div: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 20,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'exp',
+        exp: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 27,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'mod',
+        mod: {
+          type: 'objectAttribute',
           value: {
             type: 'number',
             value: 1,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'arr',
+        arr: {
+          type: 'objectAttribute',
           value: {
             type: 'array',
             of: {
@@ -759,23 +722,21 @@ t.test('values in projection', (t) => {
             },
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'and',
+        and: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: undefined,
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'or',
+        or: {
+          type: 'objectAttribute',
           value: {
             type: 'boolean',
             value: undefined,
           },
         },
-      ],
+      },
     },
   } satisfies ArrayTypeNode<ObjectTypeNode>)
 
@@ -792,22 +753,20 @@ t.test('deref', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'name',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'author',
+        author: {
+          type: 'objectAttribute',
           value: findSchemaType('author'),
         },
-      ],
+      },
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -827,65 +786,57 @@ t.test('deref with projection union', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: '_id',
+      attributes: {
+        _id: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: '_type',
+        _type: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
             value: 'post',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'name',
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'lastname',
+        lastname: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
           optional: true,
         },
-        {
-          type: 'objectKeyValue',
-          key: 'author',
+        author: {
+          type: 'objectAttribute',
           value: {
             type: 'reference',
             to: 'author',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'sluger',
+        sluger: {
+          type: 'objectAttribute',
           value: {
             type: 'reference',
             to: 'slug',
           },
           optional: true,
         },
-        {
-          type: 'objectKeyValue',
-          key: 'authorOrGhost',
+        authorOrGhost: {
+          type: 'objectAttribute',
           value: {
             type: 'union',
             of: [findSchemaType('author'), findSchemaType('ghost')],
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'allAuthorOrGhost',
+        allAuthorOrGhost: {
+          type: 'objectAttribute',
           optional: true,
           value: {
             type: 'array',
@@ -904,72 +855,64 @@ t.test('deref with projection union', (t) => {
             },
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'authorName',
+        authorName: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'authorOrGhostName',
+        authorOrGhostName: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'authorOrGhostProjected',
+        authorOrGhostProjected: {
+          type: 'objectAttribute',
           value: {
             type: 'union',
             of: [
               {
                 type: 'object',
-                fields: [
-                  {
-                    type: 'objectKeyValue',
-                    key: 'name',
+                attributes: {
+                  name: {
+                    type: 'objectAttribute',
                     value: {
                       type: 'string',
                     },
                   },
-                  {
-                    type: 'objectKeyValue',
-                    key: '_type',
+                  _type: {
+                    type: 'objectAttribute',
                     value: {
                       type: 'string',
                       value: 'author',
                     },
                   },
-                ],
+                },
               },
               {
                 type: 'object',
-                fields: [
-                  {
-                    type: 'objectKeyValue',
-                    key: 'name',
+                attributes: {
+                  name: {
+                    type: 'objectAttribute',
                     value: {
                       type: 'string',
                     },
                   },
-                  {
-                    type: 'objectKeyValue',
-                    key: '_type',
+                  _type: {
+                    type: 'objectAttribute',
                     value: {
                       type: 'string',
                       value: 'ghost',
                     },
                   },
-                ],
+                },
               },
             ],
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'resolvedAllAuthorOrGhost',
+        resolvedAllAuthorOrGhost: {
+          type: 'objectAttribute',
           value: {
             type: 'array',
             of: {
@@ -978,9 +921,9 @@ t.test('deref with projection union', (t) => {
             },
           },
         },
-      ],
+      },
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -995,40 +938,36 @@ t.test('deref with projection', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'name',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'author',
+        author: {
+          type: 'objectAttribute',
           value: {
             type: 'object',
-            fields: [
-              {
-                type: 'objectKeyValue',
-                key: '_id',
+            attributes: {
+              _id: {
+                type: 'objectAttribute',
                 value: {
                   type: 'string',
                 },
               },
-              {
-                type: 'objectKeyValue',
-                key: 'name',
+              name: {
+                type: 'objectAttribute',
                 value: {
                   type: 'string',
                 },
               },
-            ],
+            },
           },
         },
-      ],
+      },
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1044,38 +983,34 @@ t.test('deref with projection and element access', (t) => {
     of: [
       {
         type: 'object',
-        fields: [
-          {
-            type: 'objectKeyValue',
-            key: 'name',
+        attributes: {
+          name: {
+            type: 'objectAttribute',
             value: {
               type: 'string',
             },
           },
-          {
-            type: 'objectKeyValue',
-            key: 'author',
+          author: {
+            type: 'objectAttribute',
             value: {
               type: 'object',
-              fields: [
-                {
-                  type: 'objectKeyValue',
-                  key: '_id',
+              attributes: {
+                _id: {
+                  type: 'objectAttribute',
                   value: {
                     type: 'string',
                   },
                 },
-                {
-                  type: 'objectKeyValue',
-                  key: 'name',
+                name: {
+                  type: 'objectAttribute',
                   value: {
                     type: 'string',
                   },
                 },
-              ],
+              },
             },
           },
-        ],
+        },
       },
       {type: 'null'},
     ],
@@ -1095,38 +1030,34 @@ t.test('deref with element access, then projection ', (t) => {
     of: [
       {
         type: 'object',
-        fields: [
-          {
-            type: 'objectKeyValue',
-            key: 'name',
+        attributes: {
+          name: {
+            type: 'objectAttribute',
             value: {
               type: 'string',
             },
           },
-          {
-            type: 'objectKeyValue',
-            key: 'author',
+          author: {
+            type: 'objectAttribute',
             value: {
               type: 'object',
-              fields: [
-                {
-                  type: 'objectKeyValue',
-                  key: '_id',
+              attributes: {
+                _id: {
+                  type: 'objectAttribute',
                   value: {
                     type: 'string',
                   },
                 },
-                {
-                  type: 'objectKeyValue',
-                  key: 'name',
+                name: {
+                  type: 'objectAttribute',
                   value: {
                     type: 'string',
                   },
                 },
-              ],
+              },
             },
           },
-        ],
+        },
       },
       {type: 'null'},
     ],
@@ -1142,35 +1073,33 @@ t.test('subquery', (t) => {
             }
           }`
 
-  const res = evaluateQueryType(query, schemas)
+  const res = evaluateQueryType(query, [authorDocument, postDocument])
   t.strictSame(res, {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'posts',
+      attributes: {
+        posts: {
+          type: 'objectAttribute',
           value: {
             type: 'array',
             of: {
               type: 'object',
-              fields: [
-                {
-                  type: 'objectKeyValue',
-                  key: 'publishedAfterAuthor',
+              attributes: {
+                publishedAfterAuthor: {
+                  type: 'objectAttribute',
                   value: {
                     type: 'boolean',
                     value: undefined,
                   },
                 },
-              ],
+              },
             },
           },
         },
-      ],
+      },
     } satisfies TypeNode,
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1186,23 +1115,21 @@ t.test('string concetnation', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: 'name',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'fullName',
+        fullName: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
             value: undefined,
           },
         },
-      ],
+      },
     },
   } satisfies ArrayTypeNode<ObjectTypeNode>)
 
@@ -1225,47 +1152,43 @@ t.test('with select', (t) => {
       of: [
         {
           type: 'object',
-          fields: [
-            {
-              type: 'objectKeyValue',
-              key: '_type',
+          attributes: {
+            _type: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
                 value: 'post',
               },
             },
-            {
-              type: 'objectKeyValue',
-              key: 'authorName',
+            authorName: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
               },
             },
-          ],
+          },
         },
         {
           type: 'object',
-          fields: [
-            {
-              type: 'objectKeyValue',
-              key: '_type',
+          attributes: {
+            _type: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
                 value: 'author',
               },
             },
-            {
-              type: 'objectKeyValue',
-              key: 'authorName',
+            authorName: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
               },
             },
-          ],
+          },
         },
       ],
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1286,18 +1209,16 @@ t.test('with select, not guaranteed & with fallback', (t) => {
       of: [
         {
           type: 'object',
-          fields: [
-            {
-              type: 'objectKeyValue',
-              key: '_type',
+          attributes: {
+            _type: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
                 value: 'post',
               },
             },
-            {
-              type: 'objectKeyValue',
-              key: 'something',
+            something: {
+              type: 'objectAttribute',
               value: {
                 type: 'union',
                 of: [
@@ -1311,22 +1232,20 @@ t.test('with select, not guaranteed & with fallback', (t) => {
                 ],
               },
             },
-          ],
+          },
         },
         {
           type: 'object',
-          fields: [
-            {
-              type: 'objectKeyValue',
-              key: '_type',
+          attributes: {
+            _type: {
+              type: 'objectAttribute',
               value: {
                 type: 'string',
                 value: 'author',
               },
             },
-            {
-              type: 'objectKeyValue',
-              key: 'something',
+            something: {
+              type: 'objectAttribute',
               value: {
                 type: 'union',
                 of: [
@@ -1340,11 +1259,11 @@ t.test('with select, not guaranteed & with fallback', (t) => {
                 ],
               },
             },
-          ],
+          },
         },
       ],
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1360,86 +1279,76 @@ t.test('with splat', (t) => {
     type: 'array',
     of: {
       type: 'object',
-      fields: [
-        {
-          type: 'objectKeyValue',
-          key: '_id',
+      attributes: {
+        _id: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: '_type',
+        _type: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
             value: 'author',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'name',
+        name: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'firstname',
+        firstname: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'lastname',
+        lastname: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'object',
+        object: {
+          type: 'objectAttribute',
           value: {
             type: 'object',
-            fields: [
-              {
-                key: 'subfield',
-                type: 'objectKeyValue',
+            attributes: {
+              subfield: {
+                type: 'objectAttribute',
                 value: {
                   type: 'string',
                 },
               },
-            ],
+            },
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'optionalObject',
+        optionalObject: {
+          type: 'objectAttribute',
           optional: true,
           value: {
             type: 'object',
-            fields: [
-              {
-                key: 'subfield',
-                type: 'objectKeyValue',
+            attributes: {
+              subfield: {
+                type: 'objectAttribute',
                 value: {
                   type: 'string',
                 },
               },
-            ],
+            },
           },
         },
-        {
-          type: 'objectKeyValue',
-          key: 'otherName',
+        otherName: {
+          type: 'objectAttribute',
           value: {
             type: 'string',
           },
         },
-      ],
+      },
     },
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1509,16 +1418,15 @@ t.test('object', (t) => {
   const res = evaluateQueryType(query, schemas)
   t.strictSame(res, {
     type: 'object',
-    fields: [
-      {
-        type: 'objectKeyValue',
-        key: 'hello',
+    attributes: {
+      hello: {
+        type: 'objectAttribute',
         value: {
           type: 'string',
           value: 'world',
         },
       },
-    ],
+    },
   } satisfies TypeNode)
 
   t.end()
@@ -1530,7 +1438,7 @@ t.test('filter with function', (t) => {
   t.strictSame(res, {
     type: 'array',
     of: findSchemaType('author'),
-  })
+  } satisfies TypeNode)
 
   t.end()
 })
@@ -1561,7 +1469,7 @@ t.test('misc', (t) => {
       "andWithAttriute": !false && !someAttriute,
       "pt": pt::text(block)
     }`
-  const res = evaluateQueryType(query, [{type: 'document', name: 'foo', fields: []}])
+  const res = evaluateQueryType(query, [{type: 'document', name: 'foo', attributes: {}}])
   t.matchSnapshot(res)
 
   t.end()
@@ -1676,7 +1584,7 @@ function findSchemaType(name: string): TypeNode {
   if (type.type === 'document') {
     return {
       type: 'object',
-      fields: type.fields,
+      attributes: type.attributes,
     }
   }
   return type.value


### PR DESCRIPTION
The code comment should explain the approach pretty well.

Note that currently the tests fail with:

```
Suites:   1 failed, 1 of 1 completed
Asserts:  26344 failed, 10172 passed, of 36516
```

It's maybe a bit too much, especially since this only covers `OpCall` and `AccessAttribute`.

I was thinking of extending this to all the different node types that we want to support initially.