### PR TITLE
feat(typeEvaluation): let optional resolved condition be evaulated

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -160,7 +160,7 @@ function handleObjectNode(node: ObjectNode, scope: Scope) {
     if (attr.type === 'ObjectConditionalSplat') {
       const condition = resolveCondition(attr.condition, scope)
       $trace('object.conditional.splat.condition %O', condition)
-      if (condition) {
+      if (condition || condition === undefined) {
         const value = walk({node: attr.value, scope})
 
         mapObjectSplat(value, scope, (node) => {
@@ -168,8 +168,19 @@ function handleObjectNode(node: ObjectNode, scope: Scope) {
             if (!Object.hasOwn(node.attributes, name)) {
               continue
             }
+            const attribute = node.attributes[name]
 
-            attributes[name] = node.attributes[name]
+            if (condition) {
+              attributes[name] = attribute
+            } else if (condition === undefined) {
+              attributes[name] = {
+                type: 'objectAttribute',
+                value: attribute.value,
+                optional: true,
+              }
+            } else {
+              throw new Error('Unexpected condition')
+            }
           }
         })
       }

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -1248,34 +1248,3 @@ Object {
   "type": "array",
 }
 `
-
-exports[`test/typeEvaluate.test.ts TAP with conditional splat > must match snapshot 1`] = `
-Object {
-  "attributes": Object {
-    "not match": Object {
-      "type": "objectAttribute",
-      "value": Object {
-        "attributes": Object {
-          "match": Object {
-            "type": "objectAttribute",
-            "value": Object {
-              "attributes": Object {
-                "foo": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "number",
-                    "value": 1,
-                  },
-                },
-              },
-              "type": "object",
-            },
-          },
-        },
-        "type": "object",
-      },
-    },
-  },
-  "type": "object",
-}
-`

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -1450,13 +1450,49 @@ t.test('with splat', (t) => {
 
 t.test('with conditional splat', (t) => {
   const query = `{"foo": 1}{
-    "not match": {"mail" == 1 => {},
-    "match": {1 == 1 => {...}}}
-  
+    "not" == 1 => {
+      "nomatch": 0,
+    },
+    "match" == "match" => {
+      "match": 1,
+    },
+    "maybe" == $foo => {
+      "maybe": 2,
+      foo
+    }
   }`
+
   const ast = parse(query)
   const res = typeEvaluate(ast, schemas)
-  t.matchSnapshot(res)
+  t.strictSame(res, {
+    type: 'object',
+    attributes: {
+      foo: {
+        type: 'objectAttribute',
+        value: {
+          type: 'number',
+          value: 1,
+        },
+        optional: true,
+      },
+      match: {
+        type: 'objectAttribute',
+        value: {
+          type: 'number',
+          value: 1,
+        },
+      },
+      maybe: {
+        type: 'objectAttribute',
+        value: {
+          type: 'number',
+          value: 2,
+        },
+        optional: true,
+      },
+    },
+  } satisfies TypeNode)
+
   t.end()
 })
 


### PR DESCRIPTION
If a condition resolves to `undefined` it means that we can't know wether the condition is true or false, for example this might be if we are using a parameter. This change appends the undefined resolved conditions as optional attributes to the resulting type