### PR TITLE
fix: remove typeEvaluator typesVersions export

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "*": {
       "1": [
         "./dist/1.d.ts"
-      ],
-      "typeEvaluator": [
-        "./dist/typeEvaluator/index.d.ts"
       ]
     }
   },

--- a/src/typeEvaluator/index.ts
+++ b/src/typeEvaluator/index.ts
@@ -1,5 +1,24 @@
+export type {GroqFunction, GroqFunctionArg, GroqPipeFunction} from '../evaluator/functions'
+export type {Scope} from '../evaluator/scope'
+export type {Context, DereferenceFunction, Document, Executor} from '../evaluator/types'
+export * from '../nodeTypes'
+export type {
+  AnyStaticValue,
+  ArrayValue,
+  BooleanValue,
+  DateTimeValue,
+  GroqType,
+  NullValue,
+  NumberValue,
+  ObjectValue,
+  PathValue,
+  StaticValue,
+  StreamValue,
+  StringValue,
+  Value,
+} from '../values'
+export {DateTime, Path} from '../values'
 export {typeEvaluate} from './typeEvaluate'
-// @internal
 export {createReferenceTypeNode} from './typeHelpers'
 export type {
   ArrayTypeNode,


### PR DESCRIPTION
@sgulseth I noticed that the `typesVersions` array includes `typeEvaluator`.

However the file it refers to doesn't exist:
```
./dist/typeEvaluator/index.d.ts
```

Removing it in this PR as `import {typeEvaluate} from 'groq'` is how it's intended to be used.

I've also enabled reporting missing tsdoc release tags (seen when running `npm run prepublishOnly`) as I've seen some inconsistencies:
```bash
dist/__tmp__/src/evaluator/functions.d.ts:16:1 - warning ae-missing-release-tag
"GroqPipeFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/scope.d.ts:3:1 - warning ae-missing-release-tag
"Scope" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:4:1 - warning ae-missing-release-tag
"Executor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:5:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:10:1 - warning ae-missing-release-tag
"DereferenceFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:13:1 - warning ae-missing-release-tag
"EvaluateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:27:1 - warning ae-missing-release-tag
"Context" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:3:1 - warning ae-missing-release-tag
"SyntaxNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:4:1 - warning ae-missing-release-tag
"ObjectAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:10:1 - warning ae-missing-release-tag
"OpCall" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:12:1 - warning ae-missing-release-tag
"BaseNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:15:1 - warning ae-missing-release-tag
"AndNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:20:1 - warning ae-missing-release-tag
"ArrayElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:25:1 - warning ae-missing-release-tag
"ArrayNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:29:1 - warning ae-missing-release-tag
"ArrayCoerceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:33:1 - warning ae-missing-release-tag
"AscNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:37:1 - warning ae-missing-release-tag
"ContextNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:41:1 - warning ae-missing-release-tag
"DerefNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:45:1 - warning ae-missing-release-tag
"DescNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:49:1 - warning ae-missing-release-tag
"EverythingNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:52:1 - warning ae-missing-release-tag
"FuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:59:1 - warning ae-missing-release-tag
"GroupNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:63:1 - warning ae-missing-release-tag
"InRangeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:70:1 - warning ae-missing-release-tag
"NegNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:74:1 - warning ae-missing-release-tag
"NotNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:78:1 - warning ae-missing-release-tag
"ObjectAttributeValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:83:1 - warning ae-missing-release-tag
"ObjectConditionalSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:88:1 - warning ae-missing-release-tag
"ObjectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:92:1 - warning ae-missing-release-tag
"ObjectSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:96:1 - warning ae-missing-release-tag
"OpCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:102:1 - warning ae-missing-release-tag
"OrNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:107:1 - warning ae-missing-release-tag
"ParameterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:111:1 - warning ae-missing-release-tag
"ParentNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:115:1 - warning ae-missing-release-tag
"PipeFuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:122:1 - warning ae-missing-release-tag
"PosNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:126:1 - warning ae-missing-release-tag
"SelectAlternativeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:131:1 - warning ae-missing-release-tag
"SelectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:136:1 - warning ae-missing-release-tag
"SelectorNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:139:1 - warning ae-missing-release-tag
"ThisNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:142:1 - warning ae-missing-release-tag
"TupleNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:146:1 - warning ae-missing-release-tag
"ValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:150:1 - warning ae-missing-release-tag
"FlatMapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:155:1 - warning ae-missing-release-tag
"MapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:160:1 - warning ae-missing-release-tag
"AccessAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:165:1 - warning ae-missing-release-tag
"AccessElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:170:1 - warning ae-missing-release-tag
"SliceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:177:1 - warning ae-missing-release-tag
"FilterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:182:1 - warning ae-missing-release-tag
"ProjectionNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/parser.d.ts:6:1 - warning ae-missing-release-tag
"parse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:2:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:11:1 - warning ae-missing-release-tag
"TypeDeclaration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:20:1 - warning ae-missing-release-tag
"Schema" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:22:1 - warning ae-missing-release-tag
"StringTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:29:1 - warning ae-missing-release-tag
"NumberTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:36:1 - warning ae-missing-release-tag
"BooleanTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:43:1 - warning ae-missing-release-tag
"PrimitiveTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:45:1 - warning ae-missing-release-tag
"NullTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:50:1 - warning ae-missing-release-tag
"InlineTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:63:1 - warning ae-missing-release-tag
"ObjectTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:73:1 - warning ae-missing-release-tag
"ObjectAttribute" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:82:1 - warning ae-missing-release-tag
"UnionTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:89:1 - warning ae-missing-release-tag
"ArrayTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:96:1 - warning ae-missing-release-tag
"UnknownTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:101:1 - warning ae-missing-release-tag
"TypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/types.d.ts:1:1 - warning ae-missing-release-tag
"ParseOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/Path.d.ts:1:1 - warning ae-missing-release-tag
"Path" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/StreamValue.d.ts:2:1 - warning ae-missing-release-tag
"StreamValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:7:1 - warning ae-missing-release-tag
"GroqType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:11:1 - warning ae-missing-release-tag
"Value" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:12:1 - warning ae-missing-release-tag
"StringValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:13:1 - warning ae-missing-release-tag
"NumberValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:14:1 - warning ae-missing-release-tag
"NullValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:15:1 - warning ae-missing-release-tag
"BooleanValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:16:1 - warning ae-missing-release-tag
"DateTimeValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:17:1 - warning ae-missing-release-tag
"PathValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:18:1 - warning ae-missing-release-tag
"ObjectValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:19:1 - warning ae-missing-release-tag
"ArrayValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:20:1 - warning ae-missing-release-tag
"AnyStaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/utils.d.ts:3:1 - warning ae-missing-release-tag
"StaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/functions.d.ts:16:1 - warning ae-missing-release-tag
"GroqPipeFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/scope.d.ts:3:1 - warning ae-missing-release-tag
"Scope" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:4:1 - warning ae-missing-release-tag
"Executor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:5:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:10:1 - warning ae-missing-release-tag
"DereferenceFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:13:1 - warning ae-missing-release-tag
"EvaluateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:27:1 - warning ae-missing-release-tag
"Context" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:3:1 - warning ae-missing-release-tag
"SyntaxNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:4:1 - warning ae-missing-release-tag
"ObjectAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:10:1 - warning ae-missing-release-tag
"OpCall" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:12:1 - warning ae-missing-release-tag
"BaseNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:15:1 - warning ae-missing-release-tag
"AndNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:20:1 - warning ae-missing-release-tag
"ArrayElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:25:1 - warning ae-missing-release-tag
"ArrayNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:29:1 - warning ae-missing-release-tag
"ArrayCoerceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:33:1 - warning ae-missing-release-tag
"AscNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:37:1 - warning ae-missing-release-tag
"ContextNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:41:1 - warning ae-missing-release-tag
"DerefNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:45:1 - warning ae-missing-release-tag
"DescNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:49:1 - warning ae-missing-release-tag
"EverythingNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:52:1 - warning ae-missing-release-tag
"FuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:59:1 - warning ae-missing-release-tag
"GroupNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:63:1 - warning ae-missing-release-tag
"InRangeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:70:1 - warning ae-missing-release-tag
"NegNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:74:1 - warning ae-missing-release-tag
"NotNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:78:1 - warning ae-missing-release-tag
"ObjectAttributeValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:83:1 - warning ae-missing-release-tag
"ObjectConditionalSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:88:1 - warning ae-missing-release-tag
"ObjectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:92:1 - warning ae-missing-release-tag
"ObjectSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:96:1 - warning ae-missing-release-tag
"OpCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:102:1 - warning ae-missing-release-tag
"OrNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:107:1 - warning ae-missing-release-tag
"ParameterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:111:1 - warning ae-missing-release-tag
"ParentNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:115:1 - warning ae-missing-release-tag
"PipeFuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:122:1 - warning ae-missing-release-tag
"PosNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:126:1 - warning ae-missing-release-tag
"SelectAlternativeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:131:1 - warning ae-missing-release-tag
"SelectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:136:1 - warning ae-missing-release-tag
"SelectorNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:139:1 - warning ae-missing-release-tag
"ThisNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:142:1 - warning ae-missing-release-tag
"TupleNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:146:1 - warning ae-missing-release-tag
"ValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:150:1 - warning ae-missing-release-tag
"FlatMapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:155:1 - warning ae-missing-release-tag
"MapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:160:1 - warning ae-missing-release-tag
"AccessAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:165:1 - warning ae-missing-release-tag
"AccessElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:170:1 - warning ae-missing-release-tag
"SliceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:177:1 - warning ae-missing-release-tag
"FilterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:182:1 - warning ae-missing-release-tag
"ProjectionNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/parser.d.ts:6:1 - warning ae-missing-release-tag
"parse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:2:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:11:1 - warning ae-missing-release-tag
"TypeDeclaration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:20:1 - warning ae-missing-release-tag
"Schema" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:22:1 - warning ae-missing-release-tag
"StringTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:29:1 - warning ae-missing-release-tag
"NumberTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:36:1 - warning ae-missing-release-tag
"BooleanTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:43:1 - warning ae-missing-release-tag
"PrimitiveTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:45:1 - warning ae-missing-release-tag
"NullTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:50:1 - warning ae-missing-release-tag
"InlineTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:63:1 - warning ae-missing-release-tag
"ObjectTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:73:1 - warning ae-missing-release-tag
"ObjectAttribute" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:82:1 - warning ae-missing-release-tag
"UnionTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:89:1 - warning ae-missing-release-tag
"ArrayTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:96:1 - warning ae-missing-release-tag
"UnknownTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:101:1 - warning ae-missing-release-tag
"TypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/types.d.ts:1:1 - warning ae-missing-release-tag
"ParseOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/Path.d.ts:1:1 - warning ae-missing-release-tag
"Path" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/StreamValue.d.ts:2:1 - warning ae-missing-release-tag
"StreamValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:7:1 - warning ae-missing-release-tag
"GroqType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:11:1 - warning ae-missing-release-tag
"Value" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:12:1 - warning ae-missing-release-tag
"StringValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:13:1 - warning ae-missing-release-tag
"NumberValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:14:1 - warning ae-missing-release-tag
"NullValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:15:1 - warning ae-missing-release-tag
"BooleanValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:16:1 - warning ae-missing-release-tag
"DateTimeValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:17:1 - warning ae-missing-release-tag
"PathValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:18:1 - warning ae-missing-release-tag
"ObjectValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:19:1 - warning ae-missing-release-tag
"ArrayValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:20:1 - warning ae-missing-release-tag
"AnyStaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/utils.d.ts:3:1 - warning ae-missing-release-tag
"StaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/functions.d.ts:16:1 - warning ae-missing-release-tag
"GroqPipeFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/scope.d.ts:3:1 - warning ae-missing-release-tag
"Scope" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:4:1 - warning ae-missing-release-tag
"Executor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:5:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:10:1 - warning ae-missing-release-tag
"DereferenceFunction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/evaluator/types.d.ts:27:1 - warning ae-missing-release-tag
"Context" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:3:1 - warning ae-missing-release-tag
"SyntaxNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:4:1 - warning ae-missing-release-tag
"ObjectAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:10:1 - warning ae-missing-release-tag
"OpCall" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:12:1 - warning ae-missing-release-tag
"BaseNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:15:1 - warning ae-missing-release-tag
"AndNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:20:1 - warning ae-missing-release-tag
"ArrayElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:25:1 - warning ae-missing-release-tag
"ArrayNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:29:1 - warning ae-missing-release-tag
"ArrayCoerceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:33:1 - warning ae-missing-release-tag
"AscNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:37:1 - warning ae-missing-release-tag
"ContextNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:41:1 - warning ae-missing-release-tag
"DerefNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:45:1 - warning ae-missing-release-tag
"DescNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:49:1 - warning ae-missing-release-tag
"EverythingNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:52:1 - warning ae-missing-release-tag
"FuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:59:1 - warning ae-missing-release-tag
"GroupNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:63:1 - warning ae-missing-release-tag
"InRangeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:70:1 - warning ae-missing-release-tag
"NegNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:74:1 - warning ae-missing-release-tag
"NotNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:78:1 - warning ae-missing-release-tag
"ObjectAttributeValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:83:1 - warning ae-missing-release-tag
"ObjectConditionalSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:88:1 - warning ae-missing-release-tag
"ObjectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:92:1 - warning ae-missing-release-tag
"ObjectSplatNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:96:1 - warning ae-missing-release-tag
"OpCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:102:1 - warning ae-missing-release-tag
"OrNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:107:1 - warning ae-missing-release-tag
"ParameterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:111:1 - warning ae-missing-release-tag
"ParentNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:115:1 - warning ae-missing-release-tag
"PipeFuncCallNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:122:1 - warning ae-missing-release-tag
"PosNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:126:1 - warning ae-missing-release-tag
"SelectAlternativeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:131:1 - warning ae-missing-release-tag
"SelectNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:136:1 - warning ae-missing-release-tag
"SelectorNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:139:1 - warning ae-missing-release-tag
"ThisNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:142:1 - warning ae-missing-release-tag
"TupleNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:146:1 - warning ae-missing-release-tag
"ValueNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:150:1 - warning ae-missing-release-tag
"FlatMapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:155:1 - warning ae-missing-release-tag
"MapNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:160:1 - warning ae-missing-release-tag
"AccessAttributeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:165:1 - warning ae-missing-release-tag
"AccessElementNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:170:1 - warning ae-missing-release-tag
"SliceNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:177:1 - warning ae-missing-release-tag
"FilterNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/nodeTypes.d.ts:182:1 - warning ae-missing-release-tag
"ProjectionNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:2:1 - warning ae-missing-release-tag
"Document" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:11:1 - warning ae-missing-release-tag
"TypeDeclaration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:20:1 - warning ae-missing-release-tag
"Schema" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:22:1 - warning ae-missing-release-tag
"StringTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:29:1 - warning ae-missing-release-tag
"NumberTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:36:1 - warning ae-missing-release-tag
"BooleanTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:43:1 - warning ae-missing-release-tag
"PrimitiveTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:45:1 - warning ae-missing-release-tag
"NullTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:50:1 - warning ae-missing-release-tag
"InlineTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:63:1 - warning ae-missing-release-tag
"ObjectTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:73:1 - warning ae-missing-release-tag
"ObjectAttribute" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:82:1 - warning ae-missing-release-tag
"UnionTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:89:1 - warning ae-missing-release-tag
"ArrayTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:96:1 - warning ae-missing-release-tag
"UnknownTypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/typeEvaluator/types.d.ts:101:1 - warning ae-missing-release-tag
"TypeNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/Path.d.ts:1:1 - warning ae-missing-release-tag
"Path" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/StreamValue.d.ts:2:1 - warning ae-missing-release-tag
"StreamValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:7:1 - warning ae-missing-release-tag
"GroqType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:11:1 - warning ae-missing-release-tag
"Value" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:12:1 - warning ae-missing-release-tag
"StringValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:13:1 - warning ae-missing-release-tag
"NumberValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:14:1 - warning ae-missing-release-tag
"NullValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:15:1 - warning ae-missing-release-tag
"BooleanValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:16:1 - warning ae-missing-release-tag
"DateTimeValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:17:1 - warning ae-missing-release-tag
"PathValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:18:1 - warning ae-missing-release-tag
"ObjectValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:19:1 - warning ae-missing-release-tag
"ArrayValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/types.d.ts:20:1 - warning ae-missing-release-tag
"AnyStaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

dist/__tmp__/src/values/utils.d.ts:3:1 - warning ae-missing-release-tag
"StaticValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

I recommend fixing these and then set `'ae-missing-release-tag': 'error',` in `package.config.ts`