### PR TITLE
fix(typeEvaluation): map over unions to support filtering null-unions

### DIFF
--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -550,6 +550,23 @@ t.test('subfilter with projection', (t) => {
   t.end()
 })
 
+t.test('filter on null union', (t) => {
+  const query = `*[_type == "ghost"][0].concepts[_key == "hello"].name`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+  t.strictSame(
+    res,
+    nullUnion({
+      type: 'array',
+      of: {
+        type: 'string',
+      },
+    }) satisfies TypeNode,
+  )
+
+  t.end()
+})
+
 t.test('attribute access', (t) => {
   const query = `*[_type == "author"][].object.subfield`
   const ast = parse(query)


### PR DESCRIPTION
If you do a query which might return null, we get a union with null, and we then attempt to filter on it we currently return `null` since we dont support comparing unions.