### PR TITLE
feat(typeEvaluation): add support for global::count

### DIFF
--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -1,6 +1,7 @@
 import type {FuncCallNode} from '../nodeTypes'
 import {Scope} from './scope'
 import {walk} from './typeEvaluate'
+import {resolveUnionType} from './typeHelpers'
 import type {NullTypeNode, TypeNode} from './types'
 
 function unionWithoutNull(unionTypeNode: TypeNode): TypeNode {
@@ -39,6 +40,22 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         type: 'union',
         of: typeNodes,
       }
+    }
+
+    case 'global.count': {
+      if (node.args.length === 0) {
+        return {type: 'null'} satisfies NullTypeNode
+      }
+
+      const arg = walk({node: node.args[0], scope})
+
+      return resolveUnionType(arg, (arg) => {
+        if (arg.type === 'array') {
+          return {type: 'number'}
+        }
+
+        return {type: 'null'} satisfies NullTypeNode
+      })
     }
     case 'pt.text': {
       if (node.args.length === 0) {

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -1,7 +1,7 @@
 import type {FuncCallNode} from '../nodeTypes'
 import {Scope} from './scope'
 import {walk} from './typeEvaluate'
-import {resolveUnionType} from './typeHelpers'
+import {mapConcrete} from './typeHelpers'
 import type {NullTypeNode, TypeNode} from './types'
 
 function unionWithoutNull(unionTypeNode: TypeNode): TypeNode {
@@ -43,13 +43,9 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
     }
 
     case 'global.count': {
-      if (node.args.length === 0) {
-        return {type: 'null'} satisfies NullTypeNode
-      }
-
       const arg = walk({node: node.args[0], scope})
 
-      return resolveUnionType(arg, (arg) => {
+      return mapConcrete(arg, scope, (arg) => {
         if (arg.type === 'array') {
           return {type: 'number'}
         }

--- a/src/typeEvaluator/typeHelpers.ts
+++ b/src/typeEvaluator/typeHelpers.ts
@@ -1,4 +1,16 @@
-import type {ObjectAttribute, ObjectTypeNode, TypeNode, UnionTypeNode} from './types'
+import {optimizeUnions} from './optimizations'
+import type {Scope} from './scope'
+import type {
+  ArrayTypeNode,
+  BooleanTypeNode,
+  NullTypeNode,
+  NumberTypeNode,
+  ObjectAttribute,
+  ObjectTypeNode,
+  StringTypeNode,
+  TypeNode,
+  UnionTypeNode,
+} from './types'
 
 /**
  * createReferenceTypeNode creates a ObjectTypeNode representing a reference type
@@ -84,5 +96,53 @@ export function resolveUnionType(
     default: {
       return resolver(typeNode)
     }
+  }
+}
+
+type ConcreteTypeNode =
+  | BooleanTypeNode
+  | NullTypeNode
+  | NumberTypeNode
+  | StringTypeNode
+  | ArrayTypeNode
+  | ObjectTypeNode
+
+/**
+ * mapConcrete extracts a _concrete type_ from a type node, applies the mapping
+ * function to it and returns. Most notably, this will work through unions
+ * (applying the mapping function for each variant) and inline (resolving the
+ * reference).
+ *
+ * An `unknown` input type causes it to return `unknown` as well.
+ *
+ * After encountering unions the resulting types gets passed into `mergeUnions`.
+ * By default this will just union them together again.
+ */
+export function mapConcrete(
+  node: TypeNode,
+  scope: Scope,
+  mapper: (node: ConcreteTypeNode) => TypeNode,
+  mergeUnions: (nodes: TypeNode[]) => TypeNode = (nodes) =>
+    optimizeUnions({type: 'union', of: nodes}),
+): TypeNode {
+  switch (node.type) {
+    case 'boolean':
+    case 'array':
+    case 'null':
+    case 'object':
+    case 'string':
+    case 'number':
+      return mapper(node)
+    case 'unknown':
+      return node
+    case 'union':
+      return mergeUnions(node.of.map((inner) => mapConcrete(inner, scope, mapper), mergeUnions))
+    case 'inline': {
+      const resolvedInline = scope.context.lookupTypeDeclaration(node)
+      return mapConcrete(resolvedInline, scope, mapper, mergeUnions)
+    }
+    default:
+      // @ts-expect-error - we should handle each type
+      throw new Error(`Unknown type: ${node.type}`)
   }
 }

--- a/src/typeEvaluator/typeHelpers.ts
+++ b/src/typeEvaluator/typeHelpers.ts
@@ -61,3 +61,28 @@ export function nullUnion(node: TypeNode): UnionTypeNode {
     of: [node, {type: 'null'}],
   } satisfies UnionTypeNode
 }
+
+/**
+ * resolveUnionType resolves a union type by applying a resolver function to each type in the union, recursively.
+ * If it's not a union type, the resolver function is applied directly.
+ * @param typeNode - The union type to resolve
+ * @param resolver - The resolver function to apply to each type in the union
+ * @returns The resolved union type
+ * @internal
+ **/
+export function resolveUnionType(
+  typeNode: TypeNode,
+  resolver: (t: TypeNode) => TypeNode,
+): TypeNode {
+  switch (typeNode.type) {
+    case 'union': {
+      return {
+        type: 'union',
+        of: typeNode.of.map((t) => resolveUnionType(t, resolver)),
+      }
+    }
+    default: {
+      return resolver(typeNode)
+    }
+  }
+}

--- a/src/typeEvaluator/typeHelpers.ts
+++ b/src/typeEvaluator/typeHelpers.ts
@@ -74,31 +74,6 @@ export function nullUnion(node: TypeNode): UnionTypeNode {
   } satisfies UnionTypeNode
 }
 
-/**
- * resolveUnionType resolves a union type by applying a resolver function to each type in the union, recursively.
- * If it's not a union type, the resolver function is applied directly.
- * @param typeNode - The union type to resolve
- * @param resolver - The resolver function to apply to each type in the union
- * @returns The resolved union type
- * @internal
- **/
-export function resolveUnionType(
-  typeNode: TypeNode,
-  resolver: (t: TypeNode) => TypeNode,
-): TypeNode {
-  switch (typeNode.type) {
-    case 'union': {
-      return {
-        type: 'union',
-        of: typeNode.of.map((t) => resolveUnionType(t, resolver)),
-      }
-    }
-    default: {
-      return resolver(typeNode)
-    }
-  }
-}
-
 type ConcreteTypeNode =
   | BooleanTypeNode
   | NullTypeNode

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -474,7 +474,7 @@ Object {
                   "relatedPostsCount": Object {
                     "type": "objectAttribute",
                     "value": Object {
-                      "type": "unknown",
+                      "type": "number",
                     },
                   },
                 },

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -1979,6 +1979,43 @@ t.test('opcall: not equal', (t) => {
   t.end()
 })
 
+t.test('function: count', (t) => {
+  const query = `*[_type == "post"] {
+    "name": count(name),
+    "allAuthorOrGhostCount": count(allAuthorOrGhost),
+    "allAuthorOrGhostCountWithCoalesce": count(coalesce(allAuthorOrGhost, []))
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
+          value: {
+            type: 'null',
+          },
+        },
+        allAuthorOrGhostCount: {
+          type: 'objectAttribute',
+          value: nullUnion({
+            type: 'number',
+          }),
+        },
+        allAuthorOrGhostCountWithCoalesce: {
+          type: 'objectAttribute',
+          value: {
+            type: 'number',
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
* Adds support for `count(ARRAY)`
* Added a `resolveUnionType` which recursively runs the resolver on each type inside unions, same as `mapUnion`

if ok, i'll merge and then refactor mapUnion in a separate PR 