### PR TITLE
Loosen strictness for equality with unions

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -786,12 +786,17 @@ function evaluateEquality(left: TypeNode, right: TypeNode): boolean | undefined 
     return left.value === right.value
   }
   if (left.type === 'union' && isPrimitiveTypeNode(right)) {
-    return left.of.some((node) => {
-      if (isPrimitiveTypeNode(node)) {
-        return node.value === undefined || right.value === undefined || node.value === right.value
+    for (const node of left.of) {
+      // both are primitive types, and their values are equal, we can return true
+      if (isPrimitiveTypeNode(node) && node.value === right.value) {
+        return true
       }
-      return false
-    })
+
+      // both are the same type, but the value is undefined, we can't determine the result
+      if (isPrimitiveTypeNode(node) && node.value === undefined) {
+        return undefined
+      }
+    }
   }
   if (left.type !== right.type) {
     return false

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -232,6 +232,7 @@ const namespaceOneDocument = {
       value: {
         type: 'boolean',
       },
+      optional: true,
     } satisfies ObjectAttribute,
   },
 } satisfies Document
@@ -1946,6 +1947,16 @@ t.test('pos node', (t) => {
         },
       },
     },
+  })
+  t.end()
+})
+t.test('opcall: not equal', (t) => {
+  const query = `*[_type == "namespace.one" && boolField != true]`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+  t.strictSame(res, {
+    type: 'array',
+    of: findSchemaType('namespace.one'),
   })
   t.end()
 })


### PR DESCRIPTION
Change the logic for comparing equality to be the same if we are comparing nodes in an union