### PR TITLE
Hoist duplicate type nodes and fix too aggressive flattening 

### DIFF
--- a/src/typeEvaluator/optimizations.ts
+++ b/src/typeEvaluator/optimizations.ts
@@ -70,16 +70,26 @@ export function optimizeUnions(field: TypeNode): TypeNode {
       return optimizeUnions(field.of[0])
     }
 
-    // flatten union
+    // optimize sub type nodes in union
+    let unionTypeIndex = 0
+    let unionTypes = 0
     for (let idx = 0; field.of.length > idx; idx++) {
       const subField = field.of[idx]
       if (subField.type === 'union') {
-        field.of.splice(idx, 1, ...subField.of)
-        idx--
-        continue
+        unionTypeIndex = idx
+        unionTypes++
       }
 
       field.of[idx] = optimizeUnions(subField)
+    }
+
+    // flatten if there is only one union inside a union
+    if (unionTypes === 1) {
+      const unionType = field.of[unionTypeIndex]
+      // this is only to make the type checker happy
+      if (unionType.type === 'union') {
+        field.of.splice(unionTypeIndex, 1, ...unionType.of)
+      }
     }
 
     const compare = new Intl.Collator('en').compare

--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -265,11 +265,15 @@ function handleOpCallNode(node: OpCallNode, scope: Scope): TypeNode {
             }
           }
           if (left.type === 'array' && right.type === 'array') {
+            // handle the case where it's a array of known literals
+            const lhs = left.of.type === 'union' ? left.of.of : [left.of]
+            const rhs = right.of.type === 'union' ? right.of.of : [right.of]
+
             return {
               type: 'array',
               of: {
                 type: 'union',
-                of: [left.of, right.of],
+                of: [...lhs, ...rhs],
               },
             } satisfies ArrayTypeNode
           }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -1,6 +1,7 @@
 import t from 'tap'
 
 import {parse} from '../src/parser'
+import {optimizeUnions} from '../src/typeEvaluator/optimizations'
 import {typeEvaluate} from '../src/typeEvaluator/typeEvaluate'
 import {createReferenceTypeNode, nullUnion} from '../src/typeEvaluator/typeHelpers'
 import type {
@@ -2088,6 +2089,84 @@ t.test('function: references', (t) => {
         },
       },
     },
+  })
+  t.end()
+})
+
+t.test('optimizations: hoistDuplicateUnionTypeNodes', (t) => {
+  const optimized = optimizeUnions({
+    type: 'union',
+    of: [
+      {
+        type: 'union',
+        of: [
+          {
+            type: 'string',
+            value: 'foo',
+          },
+          {
+            type: 'string',
+            value: 'bar',
+          },
+          {
+            type: 'number',
+            value: 3,
+          },
+        ],
+      },
+      {
+        type: 'union',
+        of: [
+          {
+            type: 'string',
+            value: 'foo',
+          },
+          {
+            type: 'string',
+            value: 'baz',
+          },
+          {
+            type: 'number',
+            value: 2,
+          },
+        ],
+      },
+    ],
+  })
+  t.strictSame(optimized, {
+    type: 'union',
+    of: [
+      {
+        type: 'string',
+        value: 'foo',
+      },
+      {
+        type: 'union',
+        of: [
+          {
+            type: 'number',
+            value: 2,
+          },
+          {
+            type: 'string',
+            value: 'baz',
+          },
+        ],
+      },
+      {
+        type: 'union',
+        of: [
+          {
+            type: 'number',
+            value: 3,
+          },
+          {
+            type: 'string',
+            value: 'bar',
+          },
+        ],
+      },
+    ],
   })
   t.end()
 })


### PR DESCRIPTION
We were flattening a bit too much, we should only flatten if it's one union inside another union.

Should produce: `(a,b,c,d) | (a,b,e,f) = (a, b), ((c,d) | (e,f))`