### PR TITLE
fix(typeEvlauator): handle rest on object splat operations

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -269,28 +269,32 @@ function handleObjectNode(node: ObjectNode, scope: Scope) {
       // keep track of the index of the conditional splat to be able to merge the attributes correctly later.
       attributes.push(null)
 
-      conditionalVariants.push([
-        idx,
-        mapConcrete(attributeNode, scope, (attributeNode) => {
-          $trace('object.conditional.splat.result.concrete %O', attributeNode)
-          if (attributeNode.type !== 'object') {
-            return attributeNode
-          }
+      const variant = mapConcrete(attributeNode, scope, (attributeNode) => {
+        $trace('object.conditional.splat.result.concrete %O', attributeNode)
+        if (attributeNode.type !== 'object') {
+          return attributeNode
+        }
 
-          const conditionalAttributes: Record<string, ObjectAttribute> = {}
-          for (const name in attributeNode.attributes) {
-            if (!attributeNode.attributes.hasOwnProperty(name)) {
-              continue
-            }
-            conditionalAttributes[name] = attributeNode.attributes[name]
+        const conditionalAttributes: Record<string, ObjectAttribute> = {}
+        for (const name in attributeNode.attributes) {
+          if (!attributeNode.attributes.hasOwnProperty(name)) {
+            continue
           }
-          return {
-            type: 'object',
-            attributes: conditionalAttributes,
-            rest: attributeNode.rest,
-          } satisfies ObjectTypeNode
-        }),
-      ])
+          conditionalAttributes[name] = attributeNode.attributes[name]
+        }
+        return {
+          type: 'object',
+          attributes: conditionalAttributes,
+          rest: attributeNode.rest,
+        } satisfies ObjectTypeNode
+      })
+
+      // If the variant is not an object or a union of objects, we bail out early.
+      if (variant.type !== 'union' && variant.type !== 'object') {
+        return variant
+      }
+
+      conditionalVariants.push([idx, variant])
 
       continue
     }

--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -124,7 +124,7 @@ function mapObjectSplat(
   node: ConcreteTypeNode,
   scope: Scope,
   mapper: (attribute: ObjectAttribute) => ObjectAttribute,
-): TypeNode {
+): ObjectTypeNode | UnknownTypeNode | NullTypeNode {
   // if the node is not an object it means we are splating over a non-object, so we return unknown
   if (node.type !== 'object') {
     return {type: 'unknown'}
@@ -166,9 +166,12 @@ function handleObjectSplatNode(attr: ObjectSplatNode, scope: Scope): TypeNode {
   return mapConcrete(value, scope, (node) => {
     const attributes: Record<string, ObjectAttribute> = {}
     const mapped = mapObjectSplat(node, scope, (attribute) => attribute)
+
+    // mapObjectSplat can return null, unknown, or an object. If it's not an object we return it as is.
     if (mapped.type != 'object') {
       return mapped
     }
+
     for (const name in mapped.attributes) {
       if (!mapped.attributes.hasOwnProperty(name)) {
         continue
@@ -203,9 +206,11 @@ function handleObjectConditionalSplatNode(
         optional: true,
       }
     })
+    // mapObjectSplat can return null, unknown, or an object. If it's not an object we return it as is.
     if (mapped.type != 'object') {
       return mapped
     }
+
     const attributes: Record<string, ObjectAttribute> = {}
     for (const name in mapped.attributes) {
       // eslint-disable-next-line max-depth

--- a/src/typeEvaluator/typeHelpers.ts
+++ b/src/typeEvaluator/typeHelpers.ts
@@ -75,7 +75,7 @@ export function unionOf(...nodes: TypeNode[]): UnionTypeNode {
   } satisfies UnionTypeNode
 }
 
-type ConcreteTypeNode =
+export type ConcreteTypeNode =
   | BooleanTypeNode
   | NullTypeNode
   | NumberTypeNode

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -1289,32 +1289,42 @@ Object {
             "of": Array [
               Object {
                 "of": Object {
-                  "attributes": Object {
-                    "list": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "of": Object {
-                          "attributes": Object {
-                            "_id": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
-                            },
-                            "refId": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
-                            },
-                          },
-                          "type": "object",
-                        },
-                        "type": "array",
-                      },
+                  "of": Array [
+                    Object {
+                      "attributes": Object {},
+                      "type": "object",
                     },
-                  },
-                  "type": "object",
+                    Object {
+                      "attributes": Object {
+                        "list": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Object {
+                              "attributes": Object {
+                                "_id": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "refId": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                      },
+                      "rest": undefined,
+                      "type": "object",
+                    },
+                  ],
+                  "type": "union",
                 },
                 "type": "array",
               },
@@ -1326,6 +1336,85 @@ Object {
           },
         },
       },
+      "type": "object",
+    },
+    Object {
+      "type": "null",
+    },
+  ],
+  "type": "union",
+}
+`
+
+exports[`test/typeEvaluate.test.ts TAP splat object with union object > must match snapshot 1`] = `
+Object {
+  "of": Array [
+    Object {
+      "attributes": Object {
+        "_id": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "author",
+          },
+        },
+      },
+      "type": "object",
+    },
+    Object {
+      "attributes": Object {
+        "_id": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "author",
+          },
+        },
+        "firstname": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "rest": undefined,
+      "type": "object",
+    },
+    Object {
+      "attributes": Object {
+        "_id": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "author",
+          },
+        },
+        "lastname": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "rest": undefined,
       "type": "object",
     },
     Object {

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -1289,42 +1289,32 @@ Object {
             "of": Array [
               Object {
                 "of": Object {
-                  "of": Array [
-                    Object {
-                      "attributes": Object {},
-                      "type": "object",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "list": Object {
-                          "type": "objectAttribute",
-                          "value": Object {
-                            "of": Object {
-                              "attributes": Object {
-                                "_id": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
-                                },
-                                "refId": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
-                                },
+                  "attributes": Object {
+                    "list": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_id": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
                               },
-                              "type": "object",
                             },
-                            "type": "array",
+                            "refId": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
                           },
+                          "type": "object",
                         },
+                        "type": "array",
                       },
-                      "rest": undefined,
-                      "type": "object",
                     },
-                  ],
-                  "type": "union",
+                  },
+                  "type": "object",
                 },
                 "type": "array",
               },
@@ -1364,24 +1354,6 @@ Object {
             "value": "author",
           },
         },
-      },
-      "type": "object",
-    },
-    Object {
-      "attributes": Object {
-        "_id": Object {
-          "type": "objectAttribute",
-          "value": Object {
-            "type": "string",
-          },
-        },
-        "_type": Object {
-          "type": "objectAttribute",
-          "value": Object {
-            "type": "string",
-            "value": "author",
-          },
-        },
         "firstname": Object {
           "type": "objectAttribute",
           "value": Object {
@@ -1389,7 +1361,6 @@ Object {
           },
         },
       },
-      "rest": undefined,
       "type": "object",
     },
     Object {
@@ -1414,7 +1385,6 @@ Object {
           },
         },
       },
-      "rest": undefined,
       "type": "object",
     },
     Object {

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -2718,6 +2718,232 @@ t.test('scoping', (t) => {
   t.matchSnapshot(res)
   t.end()
 })
+t.test('splat object with inline', (t) => {
+  const query = `*[_type == "author" || _type == "post" || _type == "test"] {
+    _type == "author" => {
+      "bar": _id
+    },
+    _type == "test" => {
+      foo[] {
+        _type,
+        _type != "slug" => @
+      }
+    }
+  }`
+
+  const ast = parse(query)
+  const res = typeEvaluate(ast, [
+    ...schemas,
+    {
+      name: 'inline1',
+      type: 'type',
+      value: {
+        type: 'object',
+        attributes: {
+          _type: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+              value: 'inline1',
+            },
+          },
+          inlineValue1: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    {
+      name: 'inline2',
+      type: 'type',
+      value: {
+        type: 'object',
+        attributes: {
+          _type: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+              value: 'inline2',
+            },
+          },
+          inlineValue2: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    {
+      name: 'test',
+      type: 'document',
+      attributes: {
+        _type: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+            value: 'test',
+          },
+        },
+        foo: {
+          type: 'objectAttribute',
+          value: {
+            type: 'array',
+            of: {
+              type: 'union',
+              of: [
+                {
+                  type: 'object',
+                  attributes: {
+                    _key: {
+                      type: 'objectAttribute',
+                      value: {type: 'string'},
+                    },
+                  },
+                  rest: {
+                    type: 'inline',
+                    name: 'inline1',
+                  },
+                },
+                {
+                  type: 'object',
+                  attributes: {
+                    _key: {
+                      type: 'objectAttribute',
+                      value: {type: 'string'},
+                    },
+                  },
+                  rest: {
+                    type: 'inline',
+                    name: 'inline2',
+                  },
+                },
+                {
+                  type: 'object',
+                  attributes: {
+                    _key: {
+                      type: 'objectAttribute',
+                      value: {type: 'string'},
+                    },
+                  },
+                  rest: {
+                    type: 'inline',
+                    name: 'slug',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  ])
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'union',
+      of: [
+        {
+          type: 'object',
+          attributes: {},
+        },
+        {
+          type: 'object',
+          attributes: {
+            bar: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        {
+          type: 'object',
+          attributes: {
+            foo: {
+              type: 'objectAttribute',
+              value: {
+                type: 'array',
+                of: {
+                  type: 'union',
+                  of: [
+                    {
+                      type: 'object',
+                      attributes: {
+                        _type: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                            value: 'inline1',
+                          },
+                        },
+                        _key: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                          },
+                        },
+                        inlineValue1: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      attributes: {
+                        _type: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                            value: 'inline2',
+                          },
+                        },
+                        _key: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                          },
+                        },
+                        inlineValue2: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      attributes: {
+                        _type: {
+                          type: 'objectAttribute',
+                          value: {
+                            type: 'string',
+                            value: 'slug',
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  })
+  t.end()
+})
 
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3109,7 +3109,7 @@ const objectVariants: {name: string; attributes: ObjectAttributeNode[]; expects:
   },
 
   {
-    name: 'Test splatting over multiple conditionals leads to a matrix of all possible combinations',
+    name: 'Test splatting over multiple conditionals, with unions, leads to a matrix of all possible combinations',
     attributes: [
       {
         type: 'ObjectSplat',
@@ -3278,6 +3278,171 @@ const objectVariants: {name: string; attributes: ObjectAttributeNode[]; expects:
             chicken: {type: 'objectAttribute', value: {type: 'number'}, optional: true},
           },
           rest: undefined,
+        },
+      ),
+    ),
+  },
+
+  {
+    name: 'Test splatting over multiple conditionals leads to a matrix of all possible combinations',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            noah: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam2'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            bear: {type: 'objectAttribute', value: {type: 'number'}},
+            fox: {type: 'objectAttribute', value: {type: 'number'}},
+            deer: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            deer: {type: 'objectAttribute', value: {type: 'number'}},
+            elk: {type: 'objectAttribute', value: {type: 'number'}},
+            moose: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            ox: {type: 'objectAttribute', value: {type: 'number'}},
+            pig: {type: 'objectAttribute', value: {type: 'number'}},
+            chicken: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    expects: optimizeUnions(
+      unionOf(
+        {
+          type: 'object',
+          attributes: {
+            noah: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            bear: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            fox: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            deer: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+          },
+          rest: undefined,
+        },
+        {
+          type: 'object',
+          attributes: {
+            noah: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            deer: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            elk: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            moose: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+          },
+          rest: undefined,
+        },
+        {
+          type: 'object',
+          attributes: {
+            noah: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            ox: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            pig: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+            chicken: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+              optional: true,
+            },
+          },
+          rest: undefined,
+        },
+        {
+          type: 'object',
+          attributes: {
+            noah: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+          },
         },
       ),
     ),
@@ -3549,17 +3714,45 @@ const objectVariants: {name: string; attributes: ObjectAttributeNode[]; expects:
         }),
       },
     ],
-    expects: unionOf(
+    expects: {
+      type: 'unknown',
+    },
+  },
+
+  {
+    name: "Test with a type we can't splat over(union of array)",
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'foo', value: nodeWithType({type: 'boolean'})},
       {
-        type: 'object',
-        attributes: {
-          foo: {type: 'objectAttribute', value: {type: 'boolean'}},
-        },
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'array',
+              of: {
+                type: 'object',
+                attributes: {
+                  baz: {type: 'objectAttribute', value: {type: 'string'}},
+                },
+              },
+            },
+            {
+              type: 'array',
+              of: {
+                type: 'object',
+                attributes: {
+                  foo: {type: 'objectAttribute', value: {type: 'string'}},
+                },
+              },
+            },
+          ),
+        ),
       },
-      {
-        type: 'unknown',
-      },
-    ),
+    ],
+    expects: {
+      type: 'unknown',
+    },
   },
 ]
 

--- a/test/typeEvaluateObjects.test.ts
+++ b/test/typeEvaluateObjects.test.ts
@@ -1,0 +1,1500 @@
+import assert from 'node:assert'
+
+import t from 'tap'
+
+import type {ObjectAttributeNode} from '../src/nodeTypes'
+import {optimizeUnions} from '../src/typeEvaluator/optimizations'
+import {overrideTypeForNode, typeEvaluate} from '../src/typeEvaluator/typeEvaluate'
+import {unionOf} from '../src/typeEvaluator/typeHelpers'
+import type {Schema, TypeNode} from '../src/typeEvaluator/types'
+
+const nodeWithType = (type: TypeNode) => {
+  const expr = {type: 'Value', value: null} as const
+  overrideTypeForNode(expr, type)
+  return expr
+}
+
+const objectVariants: {
+  name: string
+  attributes: ObjectAttributeNode[]
+  expects?: TypeNode
+  schema?: Schema
+  asserter?: (t: Tap.Test, res: TypeNode) => void
+}[] = [
+  // normal projection attributes
+  {
+    name: 'Attribute works',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {type: 'ObjectAttributeValue', name: 'B', value: nodeWithType({type: 'number'})},
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        B: {
+          type: 'objectAttribute',
+          value: {
+            type: 'number',
+          },
+        },
+      },
+    },
+  },
+
+  {
+    name: 'Attributes works, order matters',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'number'})},
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'number',
+          },
+        },
+      },
+    },
+  },
+  // normal projection attributes end
+
+  // MARK: START: Unknown type splatting
+  {
+    name: "Test with a type we can't splat over(array)",
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'boolean'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'array',
+          of: unionOf(
+            {
+              type: 'object',
+              attributes: {
+                B: {type: 'objectAttribute', value: {type: 'string'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                C: {type: 'objectAttribute', value: {type: 'string'}},
+              },
+            },
+          ),
+        }),
+      },
+    ],
+    expects: {
+      type: 'unknown',
+    },
+  },
+
+  {
+    name: "Test with a type we can't splat over(union of array)",
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'boolean'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'array',
+              of: {
+                type: 'object',
+                attributes: {
+                  B: {type: 'objectAttribute', value: {type: 'string'}},
+                },
+              },
+            },
+            {
+              type: 'array',
+              of: {
+                type: 'object',
+                attributes: {
+                  A: {type: 'objectAttribute', value: {type: 'string'}},
+                },
+              },
+            },
+          ),
+        ),
+      },
+    ],
+    expects: {
+      type: 'unknown',
+    },
+  },
+
+  {
+    name: "Test with a type we can't splat over(number)",
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'boolean'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({type: 'number'}),
+      },
+    ],
+    expects: {
+      type: 'unknown',
+    },
+  },
+
+  {
+    name: 'Splatting over unknown type should result in unknown type',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {type: 'ObjectSplat', value: nodeWithType({type: 'unknown'})},
+    ],
+    expects: {
+      type: 'unknown',
+    },
+  },
+  {
+    name: 'Splatting over a non-object type should result in unknown type',
+    attributes: [{type: 'ObjectSplat', value: nodeWithType({type: 'string'})}],
+    expects: {
+      type: 'unknown',
+    },
+  },
+
+  // MARK: END: Unknown type splatting
+
+  {
+    name: 'Conditional splat over object with splat',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'boolean'}},
+            C: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // (1+1) = 2 combinations
+      t.strictSame(res.of.length, 2)
+    },
+    expects: optimizeUnions(
+      unionOf(
+        {
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        },
+        {
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+            B: {type: 'objectAttribute', value: {type: 'boolean'}},
+            C: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        },
+      ),
+    ),
+  },
+
+  // Doesn't test a specific query, but correctnes when expanding splats
+  {
+    name: 'Conditional splat over object with splat, overrides key',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'boolean'}},
+            B: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // (2^1) = 2 combinations
+      t.strictSame(res.of.length, 2)
+    },
+    expects: optimizeUnions(
+      unionOf(
+        {
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        },
+        {
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'boolean'}},
+            B: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        },
+      ),
+    ),
+  },
+
+  // Doesn't test a specific query, but correctnes when expanding splats
+  {
+    name: 'Splat over union of objects',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                B: {type: 'objectAttribute', value: {type: 'boolean'}},
+                C: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                D: {type: 'objectAttribute', value: {type: 'string'}},
+                E: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+          ),
+        ),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // (2^1) = 2 combinations
+      t.strictSame(res.of.length, 2)
+    },
+    expects: optimizeUnions(
+      unionOf(
+        {
+          type: 'object',
+          attributes: {
+            A: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            B: {
+              type: 'objectAttribute',
+              value: {
+                type: 'boolean',
+              },
+            },
+            C: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+            },
+          },
+        },
+        {
+          type: 'object',
+          attributes: {
+            A: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            D: {
+              type: 'objectAttribute',
+              value: {
+                type: 'string',
+              },
+            },
+            E: {
+              type: 'objectAttribute',
+              value: {
+                type: 'number',
+              },
+            },
+          },
+        },
+      ),
+    ),
+  },
+
+  // Doesn't test a specific query, but correctnes when expanding splats
+  {
+    name: 'Unresolvable conditional splat only',
+    attributes: [
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'boolean'}},
+            B: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // (1+ EMPTY) = 2 combinations
+      t.strictSame(res.of.length, 2)
+    },
+    expects: optimizeUnions(
+      unionOf(
+        {
+          type: 'object',
+          attributes: {},
+        },
+        {
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'boolean'}},
+            B: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        },
+      ),
+    ),
+  },
+
+  // Doesn't test a specific query, but correctnes when expanding splats
+  {
+    name: 'Two unresolvable conditional splats only with unions',
+    attributes: [
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                A: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                B: {type: 'objectAttribute', value: {type: 'boolean'}},
+              },
+            },
+          ),
+        ),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                C: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                D: {type: 'objectAttribute', value: {type: 'boolean'}},
+              },
+            },
+          ),
+        ),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // 3(A,B,Empty) * 3(C,D,Empty) = 9 combinations
+      t.strictSame(res.of.length, 9)
+    },
+    expects: unionOf(
+      {
+        type: 'object',
+        attributes: {},
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+          C: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+          D: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+          C: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+          D: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          C: {
+            type: 'objectAttribute',
+            value: {
+              type: 'number',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          D: {
+            type: 'objectAttribute',
+            value: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    ),
+  },
+
+  // MARK: START: Splatting over multiple conditionals
+  // Doesn't test a specific query, but correctnes when expanding splats
+
+  {
+    name: 'Test splatting over multiple conditionals leads to a matrix of all possible combinations',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam2'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'number'}},
+            C: {type: 'objectAttribute', value: {type: 'number'}},
+            D: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            E: {type: 'objectAttribute', value: {type: 'number'}},
+            F: {type: 'objectAttribute', value: {type: 'number'}},
+            G: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            H: {type: 'objectAttribute', value: {type: 'number'}},
+            I: {type: 'objectAttribute', value: {type: 'number'}},
+            J: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union')
+      assert(res.type === 'union') // TS type guard
+      // 2^3 = 8 combinations
+      t.strictSame(res.of.length, 8)
+    },
+    expects: unionOf(
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+          I: {type: 'objectAttribute', value: {type: 'number'}},
+          J: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+          I: {type: 'objectAttribute', value: {type: 'number'}},
+          J: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+          I: {type: 'objectAttribute', value: {type: 'number'}},
+          J: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+          I: {type: 'objectAttribute', value: {type: 'number'}},
+          J: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {type: 'object', attributes: {A: {type: 'objectAttribute', value: {type: 'string'}}}},
+    ),
+  },
+  // MARK: END: Splatting over multiple conditionals
+
+  /* Projection:
+   * *[_type == "someType"] {
+   *  A: someStringField,
+   *  ...{ B, C },
+   * }
+   */
+  {
+    name: 'test splat operations',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'string'}},
+            C: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        B: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        C: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+
+  /** Projection:
+   * *[_type == "someType"] {
+   *  A: someNumberField,
+   *  A: someStringField,
+   * }
+   */
+
+  {
+    name: 'order matters, and type is overwritten',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'number',
+          },
+        },
+      },
+    },
+  },
+
+  {
+    name: 'order matters, and type is overwritten',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'number'}},
+          },
+        }),
+      },
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+
+  /** Projection:
+   * *[_type == "someType"] {
+   *  A,
+   * _type == "someOtherType" => { B }
+   * }
+   */
+
+  {
+    name: 'Test conditionals that never resolves since the condition is always false',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Value', value: false},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+
+  /** Projection:
+   * *[_type == "someType"] {
+   *  A,
+   * _type == "someType" => { B }
+   * }
+   */
+
+  {
+    name: 'Test conditionals that always resolves since the condition is always true',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Value', value: true},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        B: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+
+  {
+    name: 'Test that order matters and attributes overrides conditionals',
+    attributes: [
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+    ],
+    expects: {
+      type: 'object',
+      attributes: {
+        A: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+
+  // MARK: START unresolvable conditionals
+  /** Projection:
+   * {
+   *  A,
+   * _type == "someType" => { B }
+   * }
+   */
+  {
+    name: 'Test with attribute and conditional splat with "unresolvable" condition',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+    ],
+    expects: unionOf(
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    ),
+  },
+
+  // MARK: START unresolvable conditionals
+  /** Projection:
+   * {
+   *  A,
+   * age > 10 => { B },
+   * field == "something" => { C }
+   * }
+   */
+
+  {
+    name: 'Test with attribute and multiple conditional splat with "unresolvable" condition',
+    attributes: [
+      {type: 'ObjectAttributeValue', name: 'A', value: nodeWithType({type: 'string'})},
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            B: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someOtherParam'},
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            C: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+    ],
+    expects: unionOf(
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+          C: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+          B: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+          C: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    ),
+  },
+
+  // MARK: START: Multiple conditionals with unions
+  /**
+   * Projection: {
+   *  A: someField
+   * _type == "B" || _type == "C" => @
+   * _type == "D" || _type == "E" => @
+   * _type == "F" || _type == "G" || || _type == "H" => @
+   * }
+   */
+  {
+    name: 'Test splatting over multiple conditionals, with unions, leads to a matrix of all possible combinations',
+    attributes: [
+      {
+        type: 'ObjectSplat',
+        value: nodeWithType({
+          type: 'object',
+          attributes: {
+            A: {type: 'objectAttribute', value: {type: 'string'}},
+          },
+        }),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam2'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                B: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                C: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+          ),
+        ),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                D: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                E: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+          ),
+        ),
+      },
+      {
+        type: 'ObjectConditionalSplat',
+        condition: {type: 'Parameter', name: 'someParam'},
+        value: nodeWithType(
+          unionOf(
+            {
+              type: 'object',
+              attributes: {
+                F: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                G: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                H: {type: 'objectAttribute', value: {type: 'number'}},
+              },
+            },
+          ),
+        ),
+      },
+    ],
+    asserter: (t, res) => {
+      t.ok(res.type === 'union', 'Result is a union')
+      assert(res.type === 'union') // workaround for TS
+
+      // 1 (A is always included) × 3 (choices for B|C) × 3 (choices for D|E) × 4 (choices for F|G|H) = 1×3×3×4 = 36 combinations
+      t.equal(res.of.length, 36, `Result should have 36 possible combinations`)
+    },
+    expects: unionOf(
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          B: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          C: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          D: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          E: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          F: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          G: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+          H: {type: 'objectAttribute', value: {type: 'number'}},
+        },
+      },
+      {
+        type: 'object',
+        attributes: {
+          A: {type: 'objectAttribute', value: {type: 'string'}},
+        },
+      },
+    ),
+  },
+  // MARK: END: Multiple conditionals with unions
+]
+
+for (const variant of objectVariants) {
+  t.test(`objects: ${variant.name}`, (t) => {
+    const result = typeEvaluate(
+      {
+        type: 'Object',
+        attributes: variant.attributes,
+      },
+      variant.schema || [],
+    )
+    if (variant.expects !== undefined) {
+      t.strictSame(result, variant.expects)
+    }
+
+    if (variant.asserter !== undefined) {
+      variant.asserter(t, result)
+    }
+
+    t.end()
+  })
+}


### PR DESCRIPTION
When splatting an object we didn't map over the rest property, if it's an object we should append the attributes. If `rest` is unknown we should treat the entire object as unknown.

Fixes https://github.com/sanity-io/sanity/issues/6555