### PR TITLE
fix(typeEvaluator): only add non-null TypeNodes to the coalesced union

### DIFF
--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -76,16 +76,28 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
       if (node.args.length === 0) {
         return {type: 'null'} satisfies NullTypeNode
       }
+
       const typeNodes: TypeNode[] = []
-      let canBeNull = true
+
+      // lastCanBeNull tracks if the last argument can be null, if so we need to add null to the union
+      let lastCanBeNull = true
+
       for (const arg of node.args) {
-        const type = walk({node: arg, scope})
-        typeNodes.push(unionWithoutNull(type))
-        canBeNull =
+        // use mapConcrete to get concrete resolved value, it will also optimize the unions
+        const type = mapConcrete(walk({node: arg, scope}), scope, (node) => node)
+
+        lastCanBeNull =
           type.type === 'null' || (type.type === 'union' && type.of.some((t) => t.type === 'null'))
+
+        // if the type is not null, we add it to the union
+        if (type.type !== 'null') {
+          // if the type is a union, we add all the types except null
+          typeNodes.push(unionWithoutNull(type))
+        }
       }
 
-      if (canBeNull) {
+      // if the last argument can be null, we add null to the union
+      if (lastCanBeNull) {
         typeNodes.push({type: 'null'} satisfies NullTypeNode)
       }
 

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -298,6 +298,13 @@ Object {
           "type": "union",
         },
       },
+      "nonExisting": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "fallback",
+        },
+      },
     },
     "type": "object",
   },

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -1551,7 +1551,8 @@ t.test('with conditional splat', (t) => {
 t.test('coalesce only', async (t) => {
   const query = `*[_type == "author"]{
           "name": coalesce(name, "unknown"),
-          "maybe": coalesce(optionalObject, dontExists)
+          "maybe": coalesce(optionalObject, dontExists),
+          "nonExisting": coalesce(nonExisting, "fallback")
         }`
   const ast = parse(query)
   const res = typeEvaluate(ast, schemas)


### PR DESCRIPTION
We didn't check if the type was _actual_ `null`, we only filtered out nulls from unions. This works in most cases since you usually ask for a field that _can_ be null. However if you ask for a field that will always be null(if a field doesn't exist) we would also add null. 