### PR TITLE
feat(typeEvaluator): add support for global::now() and dateTime::now()

### DIFF
--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -103,6 +103,9 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         return {type: 'null'}
       })
     }
+    case 'dateTime.now': {
+      return {type: 'string'}
+    }
     case 'global.now': {
       return {type: 'string'}
     }

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -103,6 +103,9 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         return {type: 'null'}
       })
     }
+    case 'global.now': {
+      return {type: 'string'}
+    }
     case 'global.defined': {
       return {type: 'boolean'}
     }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -2132,7 +2132,8 @@ t.test('function: global::round', (t) => {
 
 t.test('function: global::now', (t) => {
   const query = `*[_type == "post"] {
-    "now": now()
+    "now": now(),
+    "dateTimeNow": dateTime::now()
   }`
   const ast = parse(query)
   const res = typeEvaluate(ast, schemas)
@@ -2142,6 +2143,12 @@ t.test('function: global::now', (t) => {
       type: 'object',
       attributes: {
         now: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+        dateTimeNow: {
           type: 'objectAttribute',
           value: {
             type: 'string',

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -2130,6 +2130,29 @@ t.test('function: global::round', (t) => {
   t.end()
 })
 
+t.test('function: global::now', (t) => {
+  const query = `*[_type == "post"] {
+    "now": now()
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        now: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 t.test('function: global::string', (t) => {
   const query = `*[_type == "author"] {
     "number": string(age),


### PR DESCRIPTION
Low hanging fruit, always returns a string.