### PR TITLE
Make sure we are not inside a hidden scope when resolving parent nodes

### DIFF
--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -1271,3 +1271,67 @@ Object {
   "type": "array",
 }
 `
+
+exports[`test/typeEvaluate.test.ts TAP scoping > must match snapshot 1`] = `
+Object {
+  "of": Array [
+    Object {
+      "attributes": Object {
+        "_id": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "description": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Array [
+              Object {
+                "of": Object {
+                  "attributes": Object {
+                    "list": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_id": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "refId": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              Object {
+                "type": "null",
+              },
+            ],
+            "type": "union",
+          },
+        },
+      },
+      "type": "object",
+    },
+    Object {
+      "type": "null",
+    },
+  ],
+  "type": "union",
+}
+`


### PR DESCRIPTION
When resolving filters we are creating a temporarily hidden scope for each node in the current scope. Since hidden parents are only ignored when creating a new nestedScope(non-hidden) we end up counting the hidden scope.

Fixes sanity-io/sanity#6635