### PR TITLE
Add support for sanity::versionOf()

### DIFF
--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import type {FuncCallNode} from '../nodeTypes'
 import {Scope} from './scope'
 import {walk} from './typeEvaluate'
@@ -297,7 +298,13 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
       })
     }
     case 'sanity.versionOf': {
-      return {type: 'array', of: {type: 'string'}}
+      const typeNode = walk({node: node.args[0], scope})
+      return mapConcrete(typeNode, scope, (typeNode) => {
+        if (typeNode.type !== 'string') {
+          return {type: 'null'}
+        }
+        return {type: 'array', of: {type: 'string'}}
+      })
     }
     default: {
       return {type: 'unknown'}

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -296,6 +296,9 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         })
       })
     }
+    case 'sanity.versionOf': {
+      return {type: 'array', of: {type: 'string'}}
+    }
     default: {
       return {type: 'unknown'}
     }

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -276,11 +276,28 @@ t.test('Basic parsing', async (t) => {
   })
 
   t.test('sanity-functions', async (t) => {
-    const query = `sanity::dataset() + sanity::projectId()`
-    const tree = parse(query)
-    const value = await evaluate(tree, {sanity: {dataset: 'abc', projectId: 'def'}})
-    const data = await value.get()
-    t.same(data, 'abcdef')
+    t.test('sanity::dataset() and sanity::projectId()', async (t) => {
+      const query = `sanity::dataset() + sanity::projectId()`
+      const tree = parse(query)
+      const value = await evaluate(tree, {sanity: {dataset: 'abc', projectId: 'def'}})
+      const data = await value.get()
+      t.same(data, 'abcdef')
+    })
+
+    t.test('sanity::versionOf()', async (t) => {
+      const dataset = [
+        {_id: 'doc1', _version: {}},
+        {_id: 'drafts.doc1', _version: {}},
+        {_id: 'sale.doc1', _version: {}},
+        {_id: 'weekend.sale.doc1', _version: {}},
+        {_id: 'doc2', _version: {}},
+      ]
+
+      const tree = parse('{"versions": sanity::versionOf("doc1")}')
+      const value = await evaluate(tree, {dataset})
+      const data = await value.get()
+      t.same(data, {versions: ['drafts.doc1', 'sale.doc1']})
+    })
   })
 
   t.test('Custom dereference function', async (t) => {

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -2975,6 +2975,33 @@ t.test('splat object with union object', (t) => {
   t.end()
 })
 
+t.test('function: sanity::versionOf', (t) => {
+  const query = `*[_type == "author"] {
+    "versions": sanity::versionOf("foo")
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        versions: {
+          type: 'objectAttribute',
+          value: {
+            type: 'array',
+            of: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
Add a new function `sanity::versionOf()` which lists all the stored document IDs that are a version of given published document ID in arg.