### PR TITLE
Add support for sanity::documentsOf()

### DIFF
--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -466,7 +466,7 @@ sanity['documentsOf'] = async function (args, scope, execute) {
   if (value.type !== 'string') return NULL_VALUE
   const baseId = value.data
 
-  // All the document belong to a bundle ID if:
+  // A document belongs to a bundle ID if:
   //  1. Document ID is of the form bundleId.documentGroupId
   //  2. And, they have a field called _version which is an object.
   const documentIdsInBundle: string[] = []

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -334,6 +334,15 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         return {type: 'array', of: {type: 'string'}}
       })
     }
+    case 'sanity.documentsOf': {
+      const typeNode = walk({node: node.args[0], scope})
+      return mapConcrete(typeNode, scope, (typeNode) => {
+        if (typeNode.type !== 'string') {
+          return {type: 'null'}
+        }
+        return {type: 'array', of: {type: 'string'}}
+      })
+    }
     default: {
       return {type: 'unknown'}
     }

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -298,6 +298,23 @@ t.test('Basic parsing', async (t) => {
       const data = await value.get()
       t.same(data, {versions: ['drafts.doc1', 'sale.doc1']})
     })
+
+    t.test('sanity::documentsOf()', async (t) => {
+      const dataset = [
+        {_id: 'doc1', _version: {}},
+        {_id: 'drafts.doc1', _version: {}},
+        {_id: 'sale.doc1', _version: {}},
+        {_id: 'sale.doc2', _version: {}},
+        {_id: 'sale.doc3'},
+        {_id: 'weekend.sale.doc1', _version: {}},
+        {_id: 'doc2', _version: {}},
+      ]
+
+      const tree = parse('{"documentsInBundle": sanity::documentsOf("sale")}')
+      const value = await evaluate(tree, {dataset})
+      const data = await value.get()
+      t.same(data, {documentsInBundle: ['sale.doc1', 'sale.doc2']})
+    })
   })
 
   t.test('Custom dereference function', async (t) => {

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3137,6 +3137,33 @@ t.test('function: sanity::versionOf', (t) => {
   t.end()
 })
 
+t.test('function: sanity::documentsOf', (t) => {
+  const query = `*[_type == "author"] {
+    "saleBundleDocuments": sanity::documentsOf("sale")
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        saleBundleDocuments: {
+          type: 'objectAttribute',
+          value: {
+            type: 'array',
+            of: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
Add a new function `sanity::documentsOf()` which lists all the document IDs that are part of a given bundle ID in arg.