### PR TITLE
fix: pipe functions in projections

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -833,6 +833,7 @@ function extractPropertyKey(node: ExprNode): string {
   }
 
   if (
+    node.type === 'PipeFuncCall' ||
     node.type === 'Deref' ||
     node.type === 'Map' ||
     node.type === 'Projection' ||


### PR DESCRIPTION
This fixes pipe functions inside object projections, like the query below:

```js
const input = `*[_type == "user"] {
    name,
    refs[]-> | order(name)
}`;
const dataset = [
    {_id: '1', _type: 'user', name: 'Michael', refs: [{_ref:'1'}, {_ref:'2'}]},
    {_id: '2', _type: 'company', name: 'Bluth Company'},
];
```
