### PR TITLE
fix: ensure coalesce handles optional/unknown/null properly

### DIFF
--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -257,54 +257,6 @@ Object {
 }
 `
 
-exports[`test/typeEvaluate.test.ts TAP coalesce only > must match snapshot 1`] = `
-Object {
-  "of": Object {
-    "attributes": Object {
-      "maybe": Object {
-        "type": "objectAttribute",
-        "value": Object {
-          "of": Array [
-            Object {
-              "attributes": Object {
-                "subfield": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "type": "object",
-            },
-            Object {
-              "type": "null",
-            },
-          ],
-          "type": "union",
-        },
-      },
-      "name": Object {
-        "type": "objectAttribute",
-        "value": Object {
-          "of": Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "string",
-              "value": "unknown",
-            },
-          ],
-          "type": "union",
-        },
-      },
-    },
-    "type": "object",
-  },
-  "type": "array",
-}
-`
-
 exports[`test/typeEvaluate.test.ts TAP coalesce with projection > must match snapshot 1`] = `
 Object {
   "of": Array [


### PR DESCRIPTION
We weren't really handling coalesce well:
1. We were pushing `null` into the list of possible types
2. We weren't handling unknowns
3. Even if we encountered a node that could never be null due to non-optional or no nulls in union we were still continuing

Opted to remove the snapshot and rather be explicit