### PR TITLE
feat: add support for text::query()

### DIFF
--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -776,7 +776,7 @@ dateTime['now'].arity = 0
  */
 const text: FunctionSet = {}
 text['query'] = () => {
-  return NULL_VALUE
+  throw new Error('not implemented')
 }
 text['query'].arity = 1
 

--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -768,6 +768,18 @@ dateTime['now'] = async function now(_args, scope) {
 }
 dateTime['now'].arity = 0
 
+/**
+ * Text query function - no-op implementation.
+ *
+ * groq-js has no search engine, but we provide this no-op implementation
+ * to avoid throwing errors when parsing queries that use text::query().
+ */
+const text: FunctionSet = {}
+text['query'] = () => {
+  return NULL_VALUE
+}
+text['query'].arity = 1
+
 export const namespaces: NamespaceSet = {
   global: _global,
   string,
@@ -779,4 +791,5 @@ export const namespaces: NamespaceSet = {
   math,
   dateTime,
   releases,
+  text,
 }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -94,6 +94,10 @@ t.test('Expression parsing', async (t) => {
     t.test('throws when an undefined namespace is used', async (t) => {
       throwsWithMessage(t, () => parse('invalid::func()'), 'Undefined namespace: invalid')
     })
+
+    t.test('allows text namespace functions', async (t) => {
+      t.doesNotThrow(() => parse('text::query("foo bar")'))
+    })
   })
 
   t.test('throws when nothing is passed', async (t) => {


### PR DESCRIPTION
Added support for text::query(). This is purely for making the parser not throw then the function is used, as groq-js itself does not have an actual search engine. 

Added a single test for making sure usage does not throw. 

Note: I am completely new to the groq-js codebase - let me know if there is something I'm missing. 