### PR TITLE
fix(typeEvaluator): map derefs to handle inlined references

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -104,17 +104,17 @@ function mapDeref(base: TypeNode, scope: Scope): TypeNode {
 
 function handleDerefNode(node: DerefNode, scope: Scope): TypeNode {
   $trace('deref.node %O', node)
-  const base = walk({node: node.base, scope})
-  $trace('deref.base %O', base)
+  return mapNode(walk({node: node.base, scope}), scope, (base) => {
+    $trace('deref.base %O', base)
 
-  if (base.type === 'null' || base.type === 'unknown') {
-    return {type: 'null'} satisfies NullTypeNode
-  }
+    if (base.type === 'null' || base.type === 'unknown') {
+      return {type: 'null'} satisfies NullTypeNode
+    }
+    const derefedNode = mapDeref(base, scope)
+    $trace('deref.derefedNode %O', derefedNode)
 
-  const derefedNode = mapDeref(base, scope)
-  $trace('deref.derefedNode %O', derefedNode)
-
-  return derefedNode
+    return derefedNode
+  })
 }
 
 function handleObjectSplatNode(

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3328,6 +3328,137 @@ t.test('function: sanity::partOfRelease', (t) => {
   t.end()
 })
 
+t.test('deref inline', (t) => {
+  const query = `*[_type == "test"] { field-> { _type } }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, [
+    {
+      type: 'document',
+      name: 'test',
+      attributes: {
+        _type: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+            value: 'test',
+          },
+        },
+        field: {
+          type: 'objectAttribute',
+          value: {
+            type: 'inline',
+            name: 'dest',
+          },
+        },
+      },
+    },
+    {
+      type: 'type',
+      name: 'dest',
+      value: createReferenceTypeNode('post'),
+    },
+    ...schemas,
+  ])
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        field: {
+          type: 'objectAttribute',
+          value: {
+            type: 'object',
+            attributes: {
+              _type: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'string',
+                  value: 'post',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } satisfies TypeNode)
+  t.end()
+})
+
+t.test('deref union of inline', (t) => {
+  const query = `*[_type == "test"] { field-> { _type } }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, [
+    {
+      type: 'document',
+      name: 'test',
+      attributes: {
+        _type: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+            value: 'test',
+          },
+        },
+        field: {
+          type: 'objectAttribute',
+          value: {
+            type: 'inline',
+            name: 'dest',
+          },
+        },
+      },
+    },
+    {
+      type: 'type',
+      name: 'dest',
+      value: unionOf(createReferenceTypeNode('post'), createReferenceTypeNode('author'), {
+        type: 'null',
+      }),
+    },
+    ...schemas,
+  ])
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        field: {
+          type: 'objectAttribute',
+          value: unionOf(
+            {
+              type: 'object',
+              attributes: {
+                _type: {
+                  type: 'objectAttribute',
+                  value: {
+                    type: 'string',
+                    value: 'author',
+                  },
+                },
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                _type: {
+                  type: 'objectAttribute',
+                  value: {
+                    type: 'string',
+                    value: 'post',
+                  },
+                },
+              },
+            },
+            {type: 'null'},
+          ),
+        },
+      },
+    },
+  } satisfies TypeNode)
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
### Description

Map before resolving references to handle case where an inline type contains reference(s)

### What to review

### Testing

Added a few tests
