### PR TITLE
fix(typeEvaluator): resolve rest field on deref

### DIFF
--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3453,6 +3453,91 @@ t.test('deref union of inline', (t) => {
   t.end()
 })
 
+t.test('deref inline in rest', (t) => {
+  const query = `*[_type == "test"] { field-> { _type } }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, [
+    {
+      type: 'document',
+      name: 'test',
+      attributes: {
+        _type: {
+          type: 'objectAttribute',
+          value: {
+            type: 'string',
+            value: 'test',
+          },
+        },
+        field: {
+          type: 'objectAttribute',
+          value: {
+            type: 'object',
+            attributes: {
+              _key: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'string',
+                },
+              },
+            },
+            rest: {
+              type: 'inline',
+              name: 'dest',
+            },
+          },
+        },
+      },
+    },
+    {
+      type: 'type',
+      name: 'dest',
+      value: unionOf(createReferenceTypeNode('post'), createReferenceTypeNode('author'), {
+        type: 'null',
+      }),
+    },
+    ...schemas,
+  ])
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        field: {
+          type: 'objectAttribute',
+          value: unionOf(
+            {
+              type: 'object',
+              attributes: {
+                _type: {
+                  type: 'objectAttribute',
+                  value: {
+                    type: 'string',
+                    value: 'author',
+                  },
+                },
+              },
+            },
+            {
+              type: 'object',
+              attributes: {
+                _type: {
+                  type: 'objectAttribute',
+                  value: {
+                    type: 'string',
+                    value: 'post',
+                  },
+                },
+              },
+            },
+            {type: 'null'},
+          ),
+        },
+      },
+    },
+  } satisfies TypeNode)
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
### Description

Fixes a bug where if the reference object is declared on the rest as an inline type we can deref it. This is the case when it's a reference in an array(since it also needs to include the _key field

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Added a test for it.