### PR TITLE
Add geo namespace with noop

### DIFF
--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -768,6 +768,20 @@ text['query'] = () => {
 }
 text['query'].arity = 1
 
+const geo: FunctionSet = {}
+geo['latLng'] = () => {
+  throw new Error('not implemented')
+}
+geo['containes'] = () => {
+  throw new Error('not implemented')
+}
+geo['intersects'] = () => {
+  throw new Error('not implemented')
+}
+geo['distance'] = () => {
+  throw new Error('not implemented')
+}
+
 export const namespaces: NamespaceSet = {
   global: _global,
   string,
@@ -780,4 +794,5 @@ export const namespaces: NamespaceSet = {
   dateTime,
   releases,
   text,
+  geo,
 }

--- a/src/evaluator/functions.ts
+++ b/src/evaluator/functions.ts
@@ -772,7 +772,7 @@ const geo: FunctionSet = {}
 geo['latLng'] = () => {
   throw new Error('not implemented')
 }
-geo['containes'] = () => {
+geo['contains'] = () => {
   throw new Error('not implemented')
 }
 geo['intersects'] = () => {

--- a/src/typeEvaluator/typeHelpers.ts
+++ b/src/typeEvaluator/typeHelpers.ts
@@ -136,3 +136,53 @@ export function isFuncCall(node: ExprNode, name: string): boolean {
 
   return node.type === 'FuncCall' && `${node.namespace}::${node.name}` === name
 }
+
+export function createGeoJson(type: 'Point' | 'LineString' | 'Polygon' = 'Point'): ObjectTypeNode {
+  let coordinateAttribute: ArrayTypeNode = {
+    type: 'array',
+    of: {
+      type: 'number',
+    },
+  }
+  if (type === 'LineString') {
+    coordinateAttribute = {
+      type: 'array',
+      of: {
+        type: 'array',
+        of: {
+          type: 'number',
+        },
+      },
+    } satisfies ArrayTypeNode
+  }
+  if (type === 'Polygon') {
+    coordinateAttribute = {
+      type: 'array',
+      of: {
+        type: 'array',
+        of: {
+          type: 'array',
+          of: {
+            type: 'number',
+          },
+        },
+      },
+    }
+  }
+  return {
+    type: 'object',
+    attributes: {
+      type: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: type,
+        },
+      },
+      coordinates: {
+        type: 'objectAttribute',
+        value: coordinateAttribute,
+      },
+    },
+  } satisfies ObjectTypeNode
+}

--- a/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
+++ b/tap-snapshots/test/typeEvaluate.test.ts.test.cjs
@@ -940,6 +940,37 @@ Object {
           "type": "array",
         },
       },
+      "area": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "coordinates": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "of": Object {
+                  "of": Object {
+                    "of": Object {
+                      "type": "number",
+                    },
+                    "type": "array",
+                  },
+                  "type": "array",
+                },
+                "type": "array",
+              },
+            },
+            "type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "Polygon",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
       "firstname": Object {
         "type": "objectAttribute",
         "value": Object {
@@ -950,6 +981,34 @@ Object {
         "type": "objectAttribute",
         "value": Object {
           "type": "string",
+        },
+      },
+      "line": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "coordinates": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "of": Object {
+                  "of": Object {
+                    "type": "number",
+                  },
+                  "type": "array",
+                },
+                "type": "array",
+              },
+            },
+            "type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "LineString",
+              },
+            },
+          },
+          "type": "object",
         },
       },
       "name": Object {
@@ -988,6 +1047,31 @@ Object {
               "type": "objectAttribute",
               "value": Object {
                 "type": "string",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+      "position": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "coordinates": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "of": Object {
+                  "type": "number",
+                },
+                "type": "array",
+              },
+            },
+            "type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "Point",
               },
             },
           },

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -98,6 +98,9 @@ t.test('Expression parsing', async (t) => {
     t.test('allows text namespace functions', async (t) => {
       t.doesNotThrow(() => parse('text::query("foo bar")'))
     })
+    t.test('allows geo namespace functions', async (t) => {
+      t.doesNotThrow(() => parse('geo::distance([52.24, 10.21], [52.10, 10.45])'))
+    })
   })
 
   t.test('throws when nothing is passed', async (t) => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The geo function is part of the spec as an extension, but is not included as part of groq-js. This makes groq-js non-compliant in accordance with the spec with extensions. This is especially problematic in places where groq-js is relied upon to safely parse queries but not evaluate anything, eg. sanity codegen.

As functions in the text namespace are already implemented with noops to not break the parser, I have done the same for all functions in the geo namespace.

Although not a complete implementation, this is miles better than today, as the parser actually works on groq queries used in production code today. This means that projects using these features finally can at least somewhat rely on tools requiring groq-js to parse queries.

### What to review


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I have tested this change together with `@sanity/cli` running `sanity typegen generate` on a mid-sized project using geo functions a lot. This change makes the codegen successfully parse and generate valid (although "incorrect") types for queries containing any use of the `geo` functions.


Related to #141 