### PR TITLE
feat: Add parser error messages

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -885,7 +885,7 @@ class GroqSyntaxError extends Error {
 export function parse(input: string, options: ParseOptions = {}): ExprNode {
   const result = rawParse(input)
   if (result.type === 'error') {
-    throw new GroqSyntaxError(result.position, result.error)
+    throw new GroqSyntaxError(result.position, result.message)
   }
   const processor = new MarkProcessor(input, result.marks, options)
   return processor.process(EXPR_BUILDER)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -873,8 +873,8 @@ class GroqSyntaxError extends Error {
   public position: number
   public override name = 'GroqSyntaxError'
 
-  constructor(position: number) {
-    super(`Syntax error in GROQ query at position ${position}`)
+  constructor(position: number, detail: string) {
+    super(`Syntax error in GROQ query at position ${position}: ${detail}`)
     this.position = position
   }
 }
@@ -885,8 +885,8 @@ class GroqSyntaxError extends Error {
 export function parse(input: string, options: ParseOptions = {}): ExprNode {
   const result = rawParse(input)
   if (result.type === 'error') {
-    throw new GroqSyntaxError(result.position)
+    throw new GroqSyntaxError(result.position, result.error)
   }
-  const processor = new MarkProcessor(input, result.marks as Mark[], options)
+  const processor = new MarkProcessor(input, result.marks, options)
   return processor.process(EXPR_BUILDER)
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import {tryConstantEvaluate} from './evaluator'
 import {type GroqFunctionArity, namespaces, pipeFunctions} from './evaluator/functions'
-import {type Mark, MarkProcessor, type MarkVisitor} from './markProcessor'
+import {MarkProcessor, type MarkVisitor} from './markProcessor'
 import type {
   ArrayElementNode,
   ExprNode,

--- a/src/rawParser.d.ts
+++ b/src/rawParser.d.ts
@@ -13,5 +13,5 @@ export declare function parse(input: string):
   | {
       type: 'error'
       position: number
-      error: string
+      message: string
     }

--- a/src/rawParser.d.ts
+++ b/src/rawParser.d.ts
@@ -13,4 +13,5 @@ export declare function parse(input: string):
   | {
       type: 'error'
       position: number
+      error: string
     }

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -480,7 +480,8 @@ function parseExpr(str, pos, level) {
 
             if (isGroup) {
               pos = skipWS(str, pos)
-              if (str[pos] !== ')') return {type: 'error', error: 'Unexpected ")" in group', position: pos}
+              if (str[pos] !== ')')
+                return {type: 'error', error: 'Unexpected ")" in group', position: pos}
               pos++
             }
 
@@ -531,7 +532,8 @@ function parseGroupOrTuple(str, pos) {
         if (str[pos] !== ',') break
         pos = skipWS(str, pos + 1)
       }
-      if (str[pos] !== ')') return {type: 'error', error: 'Expected ")" after tuple expression', position: pos}
+      if (str[pos] !== ')')
+        return {type: 'error', error: 'Expected ")" after tuple expression', position: pos}
       pos++
       marks.push({name: 'tuple_end', position: pos})
       break
@@ -575,7 +577,8 @@ function parseTraversal(str, pos) {
       }
     }
     case '-':
-      if (str[pos + 1] !== '>') return {type: 'error', error: 'Expected ">" in reference', position: pos}
+      if (str[pos + 1] !== '>')
+        return {type: 'error', error: 'Expected ">" in reference', position: pos}
       // ->
 
       let marks = [{name: 'deref', position: startPos}]
@@ -627,7 +630,8 @@ function parseTraversal(str, pos) {
         let rhs = parseExpr(str, pos, 0)
         if (rhs.type === 'error') return rhs
         pos = skipWS(str, rhs.position)
-        if (str[pos] !== ']') return {type: 'error', error: 'Expected "]" after array expression', position: pos}
+        if (str[pos] !== ']')
+          return {type: 'error', error: 'Expected "]" after array expression', position: pos}
 
         return {
           type: 'success',
@@ -639,7 +643,8 @@ function parseTraversal(str, pos) {
         }
       }
 
-      if (str[pos] !== ']') return {type: 'error', error: 'Expected "]" after array expression', position: pos}
+      if (str[pos] !== ']')
+        return {type: 'error', error: 'Expected "]" after array expression', position: pos}
 
       return {
         type: 'success',
@@ -681,7 +686,8 @@ function parseFuncCall(str, startPos, pos) {
     if (!nameLen) return {type: 'error', error: 'Expected function name', position: pos}
     marks.push({name: 'ident', position: pos}, {name: 'ident_end', position: pos + nameLen})
     pos = skipWS(str, pos + nameLen)
-    if (str[pos] !== '(') return {type: 'error', error: 'Expected "(" after function name', position: pos}
+    if (str[pos] !== '(')
+      return {type: 'error', error: 'Expected "(" after function name', position: pos}
     pos++
     // Consume any whitespace in front of the function argument.
     pos = skipWS(str, pos)

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -32,7 +32,7 @@ function parse(str) {
     if (result.failPosition) {
       pos = result.failPosition - 1
     }
-    return {type: 'error', error: 'Unexpected end of query', position: pos}
+    return {type: 'error', message: 'Unexpected end of query', position: pos}
   }
   delete result.position
   delete result.failPosition
@@ -125,7 +125,7 @@ function parseExpr(str, pos, level) {
         pos++
         marks.push({name: 'array_end', position: pos})
       } else {
-        return {type: 'error', error: 'Expected "]" after array expression', position: pos}
+        return {type: 'error', message: 'Expected "]" after array expression', position: pos}
       }
 
       break
@@ -188,7 +188,7 @@ function parseExpr(str, pos, level) {
             pos++
           }
           let expLen = parseRegex(str, pos, NUM)
-          if (!expLen) return {type: 'error', error: 'Exponent must be a number', position: pos}
+          if (!expLen) return {type: 'error', message: 'Exponent must be a number', position: pos}
           pos += expLen
         }
 
@@ -227,7 +227,7 @@ function parseExpr(str, pos, level) {
   }
 
   if (!marks) {
-    return {type: 'error', error: 'Expected expression', position: pos}
+    return {type: 'error', message: 'Expected expression', position: pos}
   }
 
   let lhsLevel = 12
@@ -379,7 +379,7 @@ function parseExpr(str, pos, level) {
           // pipe call
           let identPos = skipWS(str, innerPos + 1)
           let identLen = parseRegex(str, identPos, IDENT)
-          if (!identLen) return {type: 'error', error: 'Expected identifier', position: identPos}
+          if (!identLen) return {type: 'error', message: 'Expected identifier', position: identPos}
           pos = identPos + identLen
           if (str[pos] === '(' || str[pos] === ':') {
             let result = parseFuncCall(str, identPos, pos)
@@ -481,7 +481,7 @@ function parseExpr(str, pos, level) {
             if (isGroup) {
               pos = skipWS(str, pos)
               if (str[pos] !== ')')
-                return {type: 'error', error: 'Expected ")" in group', position: pos}
+                return {type: 'error', message: 'Expected ")" in group', position: pos}
               pos++
             }
 
@@ -533,7 +533,7 @@ function parseGroupOrTuple(str, pos) {
         pos = skipWS(str, pos + 1)
       }
       if (str[pos] !== ')')
-        return {type: 'error', error: 'Expected ")" after tuple expression', position: pos}
+        return {type: 'error', message: 'Expected ")" after tuple expression', position: pos}
       pos++
       marks.push({name: 'tuple_end', position: pos})
       break
@@ -544,7 +544,7 @@ function parseGroupOrTuple(str, pos) {
       break
     }
     default:
-      return {type: 'error', error: `Unexpected character "${str[pos]}"`, position: pos}
+      return {type: 'error', message: `Unexpected character "${str[pos]}"`, position: pos}
   }
 
   return {type: 'success', marks, position: pos}
@@ -563,7 +563,7 @@ function parseTraversal(str, pos) {
 
       let identStart = pos
       let identLen = parseRegex(str, pos, IDENT)
-      if (!identLen) return {type: 'error', error: 'Expected identifier after "."', position: pos}
+      if (!identLen) return {type: 'error', message: 'Expected identifier after "."', position: pos}
       pos += identLen
 
       return {
@@ -578,7 +578,7 @@ function parseTraversal(str, pos) {
     }
     case '-':
       if (str[pos + 1] !== '>')
-        return {type: 'error', error: 'Expected ">" in reference', position: pos}
+        return {type: 'error', message: 'Expected ">" in reference', position: pos}
       // ->
 
       let marks = [{name: 'deref', position: startPos}]
@@ -631,7 +631,7 @@ function parseTraversal(str, pos) {
         if (rhs.type === 'error') return rhs
         pos = skipWS(str, rhs.position)
         if (str[pos] !== ']')
-          return {type: 'error', error: 'Expected "]" after array expression', position: pos}
+          return {type: 'error', message: 'Expected "]" after array expression', position: pos}
 
         return {
           type: 'success',
@@ -644,7 +644,7 @@ function parseTraversal(str, pos) {
       }
 
       if (str[pos] !== ']')
-        return {type: 'error', error: 'Expected "]" after array expression', position: pos}
+        return {type: 'error', message: 'Expected "]" after array expression', position: pos}
 
       return {
         type: 'success',
@@ -670,7 +670,7 @@ function parseTraversal(str, pos) {
     }
   }
 
-  return {type: 'error', error: 'Unexpected character in traversal', position: pos}
+  return {type: 'error', message: 'Unexpected character in traversal', position: pos}
 }
 
 function parseFuncCall(str, startPos, pos) {
@@ -683,11 +683,11 @@ function parseFuncCall(str, startPos, pos) {
     marks.push({name: 'ident', position: startPos}, {name: 'ident_end', position: pos})
     pos = skipWS(str, pos + 2)
     let nameLen = parseRegex(str, pos, IDENT)
-    if (!nameLen) return {type: 'error', error: 'Expected function name', position: pos}
+    if (!nameLen) return {type: 'error', message: 'Expected function name', position: pos}
     marks.push({name: 'ident', position: pos}, {name: 'ident_end', position: pos + nameLen})
     pos = skipWS(str, pos + nameLen)
     if (str[pos] !== '(')
-      return {type: 'error', error: 'Expected "(" after function name', position: pos}
+      return {type: 'error', message: 'Expected "(" after function name', position: pos}
     pos++
     // Consume any whitespace in front of the function argument.
     pos = skipWS(str, pos)
@@ -724,7 +724,7 @@ function parseFuncCall(str, startPos, pos) {
   }
 
   if (str[pos] !== ')') {
-    return {type: 'error', error: 'Expected ")" after function arguments', position: pos}
+    return {type: 'error', message: 'Expected ")" after function arguments', position: pos}
   }
 
   // NOTE: a bit arbitrary the func_args_end points comes before the whitespace.
@@ -776,7 +776,7 @@ function parseObject(str, pos) {
   }
 
   if (str[pos] !== '}') {
-    return {type: 'error', error: 'Expected "}" after object', position: pos}
+    return {type: 'error', message: 'Expected "}" after object', position: pos}
   }
 
   pos++
@@ -789,7 +789,7 @@ function parseString(str, pos) {
   pos = pos + 1
   const marks = [{name: 'str', position: pos}]
   str: for (; ; pos++) {
-    if (pos > str.length) return {type: 'error', error: 'Unexpected end of query', position: pos}
+    if (pos > str.length) return {type: 'error', message: 'Unexpected end of query', position: pos}
 
     switch (str[pos]) {
       case token: {

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -32,7 +32,7 @@ function parse(str) {
     if (result.failPosition) {
       pos = result.failPosition - 1
     }
-    return {type: 'error', position: pos}
+    return {type: 'error', error: 'Expected end of query', position: pos}
   }
   delete result.position
   delete result.failPosition
@@ -48,7 +48,7 @@ function parseExpr(str, pos, level) {
   // while handling the RHS of the multiplication in `1 + 2 * 3 + 4` we only parse `3`.
   //
   // `lhsLevel` is the precedence level of the currently parsed expression on
-  // the left-hand side. This is mainly used to handle non-associcativeness.
+  // the left-hand side. This is mainly used to handle non-associativeness.
 
   // This means that you'll see code like:
   // - `if (level > PREC_XXX) break`: Operator is at this precedence level.
@@ -77,34 +77,12 @@ function parseExpr(str, pos, level) {
       break
     }
     case '(': {
-      let rhs = parseExpr(str, skipWS(str, pos + 1), 0)
-      if (rhs.type === 'error') return rhs
-      pos = skipWS(str, rhs.position)
-      switch (str[pos]) {
-        case ',': {
-          // Tuples
-          marks = [{name: 'tuple', position: startPos}].concat(rhs.marks)
-          pos = skipWS(str, pos + 1)
-          while (true) {
-            rhs = parseExpr(str, pos, 0)
-            if (rhs.type === 'error') return rhs
-            pos = skipWS(str, rhs.position)
-            if (str[pos] !== ',') break
-            pos = skipWS(str, pos + 1)
-          }
-          if (str[pos] !== ')') return {type: 'error', position: pos}
-          pos++
-          marks.push({name: 'tuple_end', position: pos})
-          break
-        }
-        case ')': {
-          pos++
-          marks = [{name: 'group', position: startPos}].concat(rhs.marks)
-          break
-        }
-        default:
-          return {type: 'error', position: pos}
-      }
+      let result = parseGroupOrTuple(str, pos)
+      if (result.type === 'error') return result
+
+      pos = result.position
+      marks = result.marks
+
       break
     }
     case '!': {
@@ -147,7 +125,7 @@ function parseExpr(str, pos, level) {
         pos++
         marks.push({name: 'array_end', position: pos})
       } else {
-        return {type: 'error', position: pos}
+        return {type: 'error', error: 'Expected "]" after array expression', position: pos}
       }
 
       break
@@ -210,7 +188,7 @@ function parseExpr(str, pos, level) {
             pos++
           }
           let expLen = parseRegex(str, pos, NUM)
-          if (!expLen) return {type: 'error', position: pos}
+          if (!expLen) return {type: 'error', error: 'Exponent must be a number', position: pos}
           pos += expLen
         }
 
@@ -401,7 +379,7 @@ function parseExpr(str, pos, level) {
           // pipe call
           let identPos = skipWS(str, innerPos + 1)
           let identLen = parseRegex(str, identPos, IDENT)
-          if (!identLen) return {type: 'error', position: identPos}
+          if (!identLen) return {type: 'error', error: 'Expected identifier', position: identPos}
           pos = identPos + identLen
           if (str[pos] === '(' || str[pos] === ':') {
             let result = parseFuncCall(str, identPos, pos)
@@ -440,7 +418,7 @@ function parseExpr(str, pos, level) {
         break
       }
       case 'd': {
-        // asc
+        // desc
         if (str.slice(innerPos, innerPos + 4) !== 'desc') break loop
         if (level > PREC_ORDER || lhsLevel < PREC_ORDER) break loop
         marks.unshift({name: 'desc', position: startPos})
@@ -502,7 +480,7 @@ function parseExpr(str, pos, level) {
 
             if (isGroup) {
               pos = skipWS(str, pos)
-              if (str[pos] !== ')') return {type: 'error', position: pos}
+              if (str[pos] !== ')') return {type: 'error', error: 'Unexpected ")" in group', position: pos}
               pos++
             }
 
@@ -534,14 +512,56 @@ function parseExpr(str, pos, level) {
   return {type: 'success', marks, position: pos, failPosition}
 }
 
+function parseGroupOrTuple(str, pos) {
+  const startPos = pos
+  let marks
+  let rhs = parseExpr(str, skipWS(str, pos + 1), 0)
+  if (rhs.type === 'error') return rhs
+  pos = skipWS(str, rhs.position)
+  switch (str[pos]) {
+    case ',': {
+      // Tuples
+      marks = [{name: 'tuple', position: startPos}].concat(rhs.marks)
+      pos = skipWS(str, pos + 1)
+      while (true) {
+        rhs = parseExpr(str, pos, 0)
+        if (rhs.type === 'error') return rhs
+        marks.push(...rhs.marks)
+        pos = skipWS(str, rhs.position)
+        if (str[pos] !== ',') break
+        pos = skipWS(str, pos + 1)
+      }
+      if (str[pos] !== ')') return {type: 'error', error: 'Expected ")" after tuple expression', position: pos}
+      pos++
+      marks.push({name: 'tuple_end', position: pos})
+      break
+    }
+    case ')': {
+      pos++
+      marks = [{name: 'group', position: startPos}].concat(rhs.marks)
+      break
+    }
+    default:
+      return {type: 'error', error: `Unexpected character "${str[pos]}"`, position: pos}
+  }
+
+  return {type: 'success', marks, position: pos}
+}
+
 function parseTraversal(str, pos) {
   let startPos = pos
   switch (str[pos]) {
     case '.': {
       pos = skipWS(str, pos + 1)
+
+      // TODO: allow tuples/groups in a traversal for selectors
+      // if (str[pos] === '(') {
+      //   return parseGroupOrTuple(str, pos)
+      // }
+
       let identStart = pos
       let identLen = parseRegex(str, pos, IDENT)
-      if (!identLen) return {type: 'error', position: pos}
+      if (!identLen) return {type: 'error', error: 'Expected identifier', position: pos}
       pos += identLen
 
       return {
@@ -555,7 +575,7 @@ function parseTraversal(str, pos) {
       }
     }
     case '-':
-      if (str[pos + 1] !== '>') return {type: 'error', position: pos}
+      if (str[pos + 1] !== '>') return {type: 'error', error: 'Expected ">" in reference', position: pos}
       // ->
 
       let marks = [{name: 'deref', position: startPos}]
@@ -607,7 +627,7 @@ function parseTraversal(str, pos) {
         let rhs = parseExpr(str, pos, 0)
         if (rhs.type === 'error') return rhs
         pos = skipWS(str, rhs.position)
-        if (str[pos] !== ']') return {type: 'error', position: pos}
+        if (str[pos] !== ']') return {type: 'error', error: 'Expected "]" after array expression', position: pos}
 
         return {
           type: 'success',
@@ -619,7 +639,7 @@ function parseTraversal(str, pos) {
         }
       }
 
-      if (str[pos] !== ']') return {type: 'error', position: pos}
+      if (str[pos] !== ']') return {type: 'error', error: 'Expected "]" after array expression', position: pos}
 
       return {
         type: 'success',
@@ -645,7 +665,7 @@ function parseTraversal(str, pos) {
     }
   }
 
-  return {type: 'error', position: pos}
+  return {type: 'error', error: 'Unexpected character in traversal', position: pos}
 }
 
 function parseFuncCall(str, startPos, pos) {
@@ -658,10 +678,10 @@ function parseFuncCall(str, startPos, pos) {
     marks.push({name: 'ident', position: startPos}, {name: 'ident_end', position: pos})
     pos = skipWS(str, pos + 2)
     let nameLen = parseRegex(str, pos, IDENT)
-    if (!nameLen) return {type: 'error', position: pos}
+    if (!nameLen) return {type: 'error', error: 'Expected function name', position: pos}
     marks.push({name: 'ident', position: pos}, {name: 'ident_end', position: pos + nameLen})
     pos = skipWS(str, pos + nameLen)
-    if (str[pos] !== '(') return {type: 'error', position: pos}
+    if (str[pos] !== '(') return {type: 'error', error: 'Expected "(" after function name', position: pos}
     pos++
     // Consume any whitespace in front of the function argument.
     pos = skipWS(str, pos)
@@ -679,6 +699,16 @@ function parseFuncCall(str, startPos, pos) {
       marks = marks.concat(result.marks)
       lastPos = result.position
       pos = skipWS(str, result.position)
+
+      // TODO: allow traversals in function arguments for selectors
+      // if (str[pos] === '.') {
+      //   result = parseTraversal(str, pos)
+      //   if (result.type === 'error') return result
+      //   marks = marks.concat(result.marks)
+      //   lastPos = result.position
+      //   pos = skipWS(str, result.position)
+      // }
+
       if (str[pos] !== ',') break
       pos = skipWS(str, pos + 1)
       // Also allow trailing commas
@@ -687,7 +717,7 @@ function parseFuncCall(str, startPos, pos) {
   }
 
   if (str[pos] !== ')') {
-    return {type: 'error', position: pos}
+    return {type: 'error', error: 'Expected ")" after function arguments', position: pos}
   }
 
   // NOTE: a bit arbitrary the func_args_end points comes before the whitespace.
@@ -739,7 +769,7 @@ function parseObject(str, pos) {
   }
 
   if (str[pos] !== '}') {
-    return {type: 'error', position: pos}
+    return {type: 'error', error: 'Expected "}" after object', position: pos}
   }
 
   pos++
@@ -752,7 +782,7 @@ function parseString(str, pos) {
   pos = pos + 1
   const marks = [{name: 'str', position: pos}]
   str: for (; ; pos++) {
-    if (pos > str.length) return {type: 'error', position: pos}
+    if (pos > str.length) return {type: 'error', error: 'Unexpected end of query', position: pos}
 
     switch (str[pos]) {
       case token: {

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -250,9 +250,7 @@ function parseExpr(str, pos, level) {
       }
       marks.push({name: 'traversal_end', position: pos})
       continue
-    } else if (trav.type === 'error') {
-      return trav
-    } // ignore if type === 'warning'
+    } // ignore if type === 'error'
 
     let token = str[innerPos]
     switch (token) {
@@ -565,8 +563,7 @@ function parseTraversal(str, pos) {
 
       let identStart = pos
       let identLen = parseRegex(str, pos, IDENT)
-      // return a warning if no identifier found as this might be a range
-      if (!identLen) return {type: 'warning', error: 'Expected identifier after "."', position: pos}
+      if (!identLen) return {type: 'error', error: 'Expected identifier after "."', position: pos}
       pos += identLen
 
       return {
@@ -673,7 +670,7 @@ function parseTraversal(str, pos) {
     }
   }
 
-  return {type: 'warning', error: 'Unexpected character in traversal', position: pos}
+  return {type: 'error', error: 'Unexpected character in traversal', position: pos}
 }
 
 function parseFuncCall(str, startPos, pos) {
@@ -792,8 +789,7 @@ function parseString(str, pos) {
   pos = pos + 1
   const marks = [{name: 'str', position: pos}]
   str: for (; ; pos++) {
-    if (pos > str.length)
-      return {type: 'error', error: 'Unexpected end of query', position: str.length}
+    if (pos > str.length) return {type: 'error', error: 'Unexpected end of query', position: pos}
 
     switch (str[pos]) {
       case token: {

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -792,7 +792,8 @@ function parseString(str, pos) {
   pos = pos + 1
   const marks = [{name: 'str', position: pos}]
   str: for (; ; pos++) {
-    if (pos > str.length) return {type: 'error', error: 'Unexpected end of query', position: str.length}
+    if (pos > str.length)
+      return {type: 'error', error: 'Unexpected end of query', position: str.length}
 
     switch (str[pos]) {
       case token: {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -60,7 +60,7 @@ t.test('Error reporting', async (t) => {
     } catch (error: any) {
       t.same(error.name, 'GroqSyntaxError')
       t.same(error.position, 13)
-      t.same(error.message, 'Syntax error in GROQ query at position 13')
+      t.same(error.message, 'Syntax error in GROQ query at position 13: Unexpected end of query')
     }
   })
 })
@@ -76,15 +76,27 @@ t.test('Expression parsing', async (t) => {
     })
   })
 
+  t.test('when parsing numbers', async (t) => {
+    t.test('throws when the exponent is not a number', async (t) => {
+      throwsWithMessage(t, () => parse('1.2eX'), 'Syntax error in GROQ query at position 4: Exponent must be a number')
+    })
+  })
+
   t.test('when parsing objects', async (t) => {
     t.test('throws when the object is not terminated properly', async (t) => {
-      throwsWithMessage(t, () => parse('*{a, b'), 'Syntax error in GROQ query at position 5')
+      throwsWithMessage(t, () => parse('*{a, b'), 'Syntax error in GROQ query at position 6: Expected \"}\" after object')
+    })
+  })
+
+  t.test('when parsing arrays', async (t) => {
+    t.test('throws when the array is not terminated properly', async (t) => {
+      throwsWithMessage(t, () => parse('{"a":[0}'), 'Syntax error in GROQ query at position 7: Expected \"]\" after array expression')
     })
   })
 
   t.test('when parsing functions', async (t) => {
     t.test('throws when the function call is not terminated properly', async (t) => {
-      throwsWithMessage(t, () => parse('count(*[]'), 'Syntax error in GROQ query at position 9')
+      throwsWithMessage(t, () => parse('count(*[]'), 'Syntax error in GROQ query at position 9: Expected \")\" after function arguments')
     })
 
     t.test('throws when using boost() when `allowBoost` is false', async (t) => {
@@ -104,15 +116,37 @@ t.test('Expression parsing', async (t) => {
   })
 
   t.test('throws when nothing is passed', async (t) => {
-    throwsWithMessage(t, () => parse(''), 'Syntax error in GROQ query at position 0')
+    throwsWithMessage(t, () => parse(''), 'Syntax error in GROQ query at position 0: Expected expression')
   })
 
-  t.test('has support for tuples', async (t) => {
-    t.doesNotThrow(() => parse('(a, b, c)'))
+  t.test('when parsing tuples', async (t) => {
+    t.test('has support for tuples', async (t) => {
+      t.doesNotThrow(() => parse('(a, b, c)'))
+    })
+
+    t.test('throws when the tuple has a syntax error', async (t) => {
+      throwsWithMessage(t, () => parse('(a, b;)'), 'Syntax error in GROQ query at position 5: Expected \")\" after tuple expression')
+    })
+  })
+
+  t.test('when parsing groups', async (t) => {
+    t.test('has support for groups', async (t) => {
+      t.doesNotThrow(() => parse('(a)'))
+    })
+
+    t.test('throws when the group has a syntax error', async (t) => {
+      throwsWithMessage(t, () => parse('(a;)'), 'Syntax error in GROQ query at position 2: Unexpected character \";\"')
+    })
+  })
+
+  t.test('when parsing traversals', async (t) => {
+    t.test('throws when deref is missing >', async (t) => {
+      throwsWithMessage(t, () => parse('*[father-name == "Michael"]'), 'Syntax error in GROQ query at position 8: Expected \">\" in reference')
+    })
   })
 
   t.test('throws when an open square bracket has no closing match', async (t) => {
-    throwsWithMessage(t, () => parse('*[foo == [1, 2'), 'Syntax error in GROQ query at position 13')
+    throwsWithMessage(t, () => parse('*[foo == [1, 2'), 'Syntax error in GROQ query at position 14: Expected \"]\" after array expression')
   })
 
   t.test('when parsing pipecalls', async (t) => {
@@ -122,6 +156,10 @@ t.test('Expression parsing', async (t) => {
 
     t.test('throws when using an invalid function', async (t) => {
       throwsWithMessage(t, () => parse('* | func()'), 'Undefined pipe function: func')
+    })
+
+    t.test('throws when using invalid syntax', async (t) => {
+      throwsWithMessage(t, () => parse('* | 1'), 'Syntax error in GROQ query at position 4: Expected identifier')
     })
   })
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -91,7 +91,7 @@ t.test('Expression parsing', async (t) => {
       throwsWithMessage(
         t,
         () => parse('*{a, b'),
-        'Syntax error in GROQ query at position 6: Expected \"}\" after object',
+        'Syntax error in GROQ query at position 5: Unexpected end of query',
       )
     })
   })
@@ -167,21 +167,11 @@ t.test('Expression parsing', async (t) => {
     })
   })
 
-  t.test('when parsing traversals', async (t) => {
-    t.test('throws when deref is missing >', async (t) => {
-      throwsWithMessage(
-        t,
-        () => parse('*[father-name == "Michael"]'),
-        'Syntax error in GROQ query at position 8: Expected \">\" in reference',
-      )
-    })
-  })
-
   t.test('throws when an open square bracket has no closing match', async (t) => {
     throwsWithMessage(
       t,
       () => parse('*[foo == [1, 2'),
-      'Syntax error in GROQ query at position 14: Expected \"]\" after array expression',
+      'Syntax error in GROQ query at position 13: Unexpected end of query',
     )
   })
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -78,25 +78,41 @@ t.test('Expression parsing', async (t) => {
 
   t.test('when parsing numbers', async (t) => {
     t.test('throws when the exponent is not a number', async (t) => {
-      throwsWithMessage(t, () => parse('1.2eX'), 'Syntax error in GROQ query at position 4: Exponent must be a number')
+      throwsWithMessage(
+        t,
+        () => parse('1.2eX'),
+        'Syntax error in GROQ query at position 4: Exponent must be a number',
+      )
     })
   })
 
   t.test('when parsing objects', async (t) => {
     t.test('throws when the object is not terminated properly', async (t) => {
-      throwsWithMessage(t, () => parse('*{a, b'), 'Syntax error in GROQ query at position 6: Expected \"}\" after object')
+      throwsWithMessage(
+        t,
+        () => parse('*{a, b'),
+        'Syntax error in GROQ query at position 6: Expected \"}\" after object',
+      )
     })
   })
 
   t.test('when parsing arrays', async (t) => {
     t.test('throws when the array is not terminated properly', async (t) => {
-      throwsWithMessage(t, () => parse('{"a":[0}'), 'Syntax error in GROQ query at position 7: Expected \"]\" after array expression')
+      throwsWithMessage(
+        t,
+        () => parse('{"a":[0}'),
+        'Syntax error in GROQ query at position 7: Expected \"]\" after array expression',
+      )
     })
   })
 
   t.test('when parsing functions', async (t) => {
     t.test('throws when the function call is not terminated properly', async (t) => {
-      throwsWithMessage(t, () => parse('count(*[]'), 'Syntax error in GROQ query at position 9: Expected \")\" after function arguments')
+      throwsWithMessage(
+        t,
+        () => parse('count(*[]'),
+        'Syntax error in GROQ query at position 9: Expected \")\" after function arguments',
+      )
     })
 
     t.test('throws when using boost() when `allowBoost` is false', async (t) => {
@@ -116,7 +132,11 @@ t.test('Expression parsing', async (t) => {
   })
 
   t.test('throws when nothing is passed', async (t) => {
-    throwsWithMessage(t, () => parse(''), 'Syntax error in GROQ query at position 0: Expected expression')
+    throwsWithMessage(
+      t,
+      () => parse(''),
+      'Syntax error in GROQ query at position 0: Expected expression',
+    )
   })
 
   t.test('when parsing tuples', async (t) => {
@@ -125,7 +145,11 @@ t.test('Expression parsing', async (t) => {
     })
 
     t.test('throws when the tuple has a syntax error', async (t) => {
-      throwsWithMessage(t, () => parse('(a, b;)'), 'Syntax error in GROQ query at position 5: Expected \")\" after tuple expression')
+      throwsWithMessage(
+        t,
+        () => parse('(a, b;)'),
+        'Syntax error in GROQ query at position 5: Expected \")\" after tuple expression',
+      )
     })
   })
 
@@ -135,18 +159,30 @@ t.test('Expression parsing', async (t) => {
     })
 
     t.test('throws when the group has a syntax error', async (t) => {
-      throwsWithMessage(t, () => parse('(a;)'), 'Syntax error in GROQ query at position 2: Unexpected character \";\"')
+      throwsWithMessage(
+        t,
+        () => parse('(a;)'),
+        'Syntax error in GROQ query at position 2: Unexpected character \";\"',
+      )
     })
   })
 
   t.test('when parsing traversals', async (t) => {
     t.test('throws when deref is missing >', async (t) => {
-      throwsWithMessage(t, () => parse('*[father-name == "Michael"]'), 'Syntax error in GROQ query at position 8: Expected \">\" in reference')
+      throwsWithMessage(
+        t,
+        () => parse('*[father-name == "Michael"]'),
+        'Syntax error in GROQ query at position 8: Expected \">\" in reference',
+      )
     })
   })
 
   t.test('throws when an open square bracket has no closing match', async (t) => {
-    throwsWithMessage(t, () => parse('*[foo == [1, 2'), 'Syntax error in GROQ query at position 14: Expected \"]\" after array expression')
+    throwsWithMessage(
+      t,
+      () => parse('*[foo == [1, 2'),
+      'Syntax error in GROQ query at position 14: Expected \"]\" after array expression',
+    )
   })
 
   t.test('when parsing pipecalls', async (t) => {
@@ -159,7 +195,11 @@ t.test('Expression parsing', async (t) => {
     })
 
     t.test('throws when using invalid syntax', async (t) => {
-      throwsWithMessage(t, () => parse('* | 1'), 'Syntax error in GROQ query at position 4: Expected identifier')
+      throwsWithMessage(
+        t,
+        () => parse('* | 1'),
+        'Syntax error in GROQ query at position 4: Expected identifier',
+      )
     })
   })
 


### PR DESCRIPTION
### Description

When the parser encounters a syntax error, we now return a message indicating what was wrong. This should be helpful in diagnosing problems and debugging issues.

### What to review

Ensure all errors correctly describe the problem and are grammatically correct and understandable.

### Testing

Unit tests should verify each type of error returns the expected error message.
