### PR TITLE
feat: Add support for diff::changedOnly

### DIFF
--- a/src/evaluator/keyPath.ts
+++ b/src/evaluator/keyPath.ts
@@ -1,4 +1,5 @@
-import type {Value} from '../values'
+import {fromJS, type Value} from '../values'
+import {deepEqual} from './equality'
 import type {KeyPath} from './types'
 
 export async function valueAtPath(arg: Value, keyPath: KeyPath): Promise<any> {
@@ -17,4 +18,59 @@ export async function valueAtPath(arg: Value, keyPath: KeyPath): Promise<any> {
     if (!current) break
   }
   return current
+}
+
+export function startsWith(keyPath: KeyPath, prefix: KeyPath): boolean {
+  return prefix.every((item, index) => keyPath[index] === item)
+}
+
+export async function* diffKeyPaths(before: Value, after: Value): AsyncGenerator<KeyPath> {
+  // a queue of paths to investigate for differences
+  const currPaths: KeyPath[] = [[]]
+  while (currPaths.length > 0) {
+    const currPath: KeyPath = currPaths.shift() || []
+    const b = fromJS(await valueAtPath(before, currPath))
+    const a = fromJS(await valueAtPath(after, currPath))
+
+    if (a.type !== b.type) {
+      yield currPath
+    } else if (
+      (a.type === 'string' && b.type === 'string') ||
+      (a.type === 'boolean' && b.type === 'boolean') ||
+      (a.type === 'null' && b.type === 'null') ||
+      (a.type === 'number' && b.type === 'number')
+    ) {
+      if (a.data !== b.data) yield currPath
+    } else if (a.type === 'datetime' && b.type === 'datetime') {
+      if (!a.data.equals(b.data)) yield currPath
+    } else if (a.type === 'object' && b.type === 'object') {
+      if (!deepEqual(a.data, b.data)) {
+        const aKeys = Object.keys(a.data)
+        const bKeys = Object.keys(b.data)
+        const keys = new Set(aKeys.concat(bKeys))
+        keys.forEach((key) => {
+          currPaths.push([...currPath, key])
+        })
+      }
+    } else if (a.type === 'array' && b.type === 'array') {
+      if (a.data.length !== b.data.length) {
+        yield currPath
+      } else if (!deepEqual(a.data, b.data)) {
+        for (let i = 0; i < b.data.length; i++) {
+          currPaths.push([...currPath, i])
+        }
+      }
+    } else if (a.type === 'stream' && b.type === 'stream') {
+      const arrayA = await a.get()
+      const arrayB = await b.get()
+
+      if (arrayA.length !== arrayB.length) {
+        yield currPath
+      } else if (!deepEqual(arrayA, arrayB)) {
+        for (let i = 0; i < arrayB.length; i++) {
+          currPaths.push([...currPath, i])
+        }
+      }
+    }
+  }
 }

--- a/src/values/StreamValue.ts
+++ b/src/values/StreamValue.ts
@@ -19,7 +19,7 @@ export class StreamValue {
     return true
   }
 
-  async get(): Promise<any> {
+  async get(): Promise<any[]> {
     const result = []
     for await (const value of this) {
       result.push(await value.get())

--- a/test/evaluator/keyPath.test.ts
+++ b/test/evaluator/keyPath.test.ts
@@ -74,7 +74,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, [[]], pair.label)
     }
   })
@@ -92,7 +92,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, [], pair.label)
     }
   })
@@ -106,7 +106,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, pair.expected, pair.label)
     }
   })
@@ -121,7 +121,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, [], pair.label)
     }
   })
@@ -144,7 +144,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, pair.expected, pair.label)
     }
   })
@@ -157,7 +157,7 @@ t.test('diffKeyPaths', async (t) => {
     ]
 
     for (const pair of pairs) {
-      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      const result = await fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
       t.same(result, [], pair.label)
     }
   })
@@ -176,7 +176,7 @@ t.test('diffKeyPaths', async (t) => {
 
     const streamA = new StreamValue(a)
     const streamB = new StreamValue(b)
-    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    const result = await fromAsync(diffKeyPaths(streamA, streamB))
     t.same(result, [[2]], 'streams')
   })
 
@@ -193,7 +193,7 @@ t.test('diffKeyPaths', async (t) => {
 
     const streamA = new StreamValue(a)
     const streamB = new StreamValue(b)
-    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    const result = await fromAsync(diffKeyPaths(streamA, streamB))
     t.same(result, [[]], 'streams')
   })
 
@@ -211,7 +211,20 @@ t.test('diffKeyPaths', async (t) => {
 
     const streamA = new StreamValue(a)
     const streamB = new StreamValue(b)
-    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    const result = await fromAsync(diffKeyPaths(streamA, streamB))
     t.same(result, [], 'streams')
   })
 })
+
+async function fromAsync<T>(generator: AsyncGenerator<T>): Promise<Array<T>> {
+  const result = Array<T>(0)
+
+  let i = 0
+  for await (const item of generator) {
+    result[i] = item
+
+    i++
+  }
+
+  return result
+}

--- a/test/evaluator/keyPath.test.ts
+++ b/test/evaluator/keyPath.test.ts
@@ -1,37 +1,217 @@
 import t from 'tap'
-import {valueAtPath} from '../../src/evaluator/keyPath'
-import {fromJS} from '../../src/values'
+import {diffKeyPaths, startsWith, valueAtPath} from '../../src/evaluator/keyPath'
+import {DateTime, fromJS, StreamValue} from '../../src/values'
 
 const obj: any = {left: {a: 1}, right: [{foo: 2}, [{bar: 3}]]}
 
 t.test('valueAtPath', async (tt) => {
   await tt.test('no parts', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), [])
-    ttt.match(value, obj)
+    ttt.same(value, obj)
   })
 
   await tt.test('one part', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), ['left'])
-    ttt.match(value, obj.left)
+    ttt.same(value, obj.left)
   })
 
   await tt.test('two parts', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), ['left', 'a'])
-    ttt.match(value, obj.left.a)
+    ttt.same(value, obj.left.a)
   })
 
   await tt.test('array and object', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), ['right', 0, 'foo'])
-    ttt.match(value, obj.right[0].foo)
+    ttt.same(value, obj.right[0].foo)
   })
 
   await tt.test('array and sub-array', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), ['right', 1, 0])
-    ttt.match(value, obj.right[1][0])
+    ttt.same(value, obj.right[1][0])
   })
 
   await tt.test('array and sub-array and object', async (ttt) => {
     const value = await valueAtPath(fromJS(obj), ['right', 1, 0, 'bar'])
-    ttt.match(value, obj.right[1][0].bar)
+    ttt.same(value, obj.right[1][0].bar)
+  })
+})
+
+t.test('startsWith', async (t) => {
+  await t.test('empty path', async (t) => {
+    t.ok(startsWith([], []))
+  })
+
+  await t.test('one entry path', async (t) => {
+    t.ok(startsWith(['a'], ['a']), 'a')
+    t.notOk(startsWith(['a'], ['b']), 'a')
+    t.ok(startsWith(['a'], []), 'a')
+    t.ok(startsWith([1], [1]), '[1]')
+    t.notOk(startsWith([1], [2]), '[1]')
+    t.ok(startsWith([1], []), '[1]')
+  })
+
+  await t.test('two entry path', async (t) => {
+    t.ok(startsWith(['a', 'b'], ['a']), 'a.b')
+    t.notOk(startsWith(['a', 'b'], ['b']), 'a.b')
+    t.ok(startsWith(['a', 2], ['a']), 'a[2]')
+    t.ok(startsWith(['a', 2], ['a', 2]), 'a[2]')
+    t.notOk(startsWith(['a', 2], [2]), 'a[2]')
+    t.notOk(startsWith(['a', 2], ['a', '2']), 'a[2]')
+  })
+})
+
+t.test('diffKeyPaths', async (t) => {
+  await t.test('diff basic values', async (t) => {
+    const pairs = [
+      {label: 'strings', a: 'a', b: 'b'},
+      {label: 'booleans', a: true, b: false},
+      {label: 'numbers', a: 1, b: 2},
+      {
+        label: 'dates',
+        a: new DateTime(new Date(2000, 0, 1)),
+        b: new DateTime(new Date(2000, 0, 2)),
+      },
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, [[]], pair.label)
+    }
+  })
+
+  await t.test('equal basic values', async (t) => {
+    const pairs = [
+      {label: 'strings', a: 'a', b: 'a'},
+      {label: 'booleans', a: true, b: true},
+      {label: 'numbers', a: 1, b: 1},
+      {
+        label: 'dates',
+        a: new DateTime(new Date(2000, 0, 1)),
+        b: new DateTime(new Date(2000, 0, 1)),
+      },
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, [], pair.label)
+    }
+  })
+
+  await t.test('diff object values', async (t) => {
+    const pairs = [
+      {label: 'nested', a: {x: 1}, b: {x: 2}, expected: [['x']]},
+      {label: 'nested two deep', a: {x: {y: 1}}, b: {x: {y: 2}}, expected: [['x', 'y']]},
+      {label: 'nested, partly equal', a: {x: 1, y: 3}, b: {x: 2, y: 3}, expected: [['x']]},
+      {label: 'nested, two diff', a: {x: 1, y: 3}, b: {x: 2, y: 4}, expected: [['x'], ['y']]},
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, pair.expected, pair.label)
+    }
+  })
+
+  await t.test('equal object values', async (t) => {
+    const pairs = [
+      {label: 'empty', a: {}, b: {}},
+      {label: 'nested', a: {x: 1}, b: {x: 1}},
+      {label: 'nested two deep', a: {x: {y: 1}}, b: {x: {y: 1}}},
+      {label: 'nested, two equal', a: {x: 1, y: 3}, b: {x: 1, y: 3}},
+      {label: 'nested, two deep', a: {x: 1, y: {z: 2}}, b: {x: 1, y: {z: 2}}},
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, [], pair.label)
+    }
+  })
+
+  await t.test('diff array values', async (t) => {
+    const pairs = [
+      {label: 'diff length', a: [1, 2], b: [1, 2, 3], expected: [[]]},
+      {label: 'diff inside object', a: {foo: [1, 2]}, b: {foo: [1, 2, 3]}, expected: [['foo']]},
+      {label: 'diff values', a: [1, 2], b: [3, 4], expected: [[0], [1]]},
+      {
+        label: 'diff nested',
+        a: [1, [2, 3]],
+        b: [1, [3, 4]],
+        expected: [
+          [1, 0],
+          [1, 1],
+        ],
+      },
+      {label: 'diff types', a: [1, '2'], b: ['1', 2], expected: [[0], [1]]},
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, pair.expected, pair.label)
+    }
+  })
+
+  await t.test('equal array values', async (t) => {
+    const pairs = [
+      {label: 'simple', a: [1, 2, 3], b: [1, 2, 3]},
+      {label: 'nested', a: [1, [2, 3]], b: [1, [2, 3]]},
+      {label: 'empty', a: [], b: []},
+    ]
+
+    for (const pair of pairs) {
+      const result = await Array.fromAsync(diffKeyPaths(fromJS(pair.a), fromJS(pair.b)))
+      t.same(result, [], pair.label)
+    }
+  })
+
+  await t.test('diff stream values', async (t) => {
+    async function* a() {
+      yield fromJS(1)
+      yield Promise.resolve(fromJS(2))
+      yield fromJS(3)
+    }
+    async function* b() {
+      yield fromJS(1)
+      yield Promise.resolve(fromJS(2))
+      yield fromJS(4)
+    }
+
+    const streamA = new StreamValue(a)
+    const streamB = new StreamValue(b)
+    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    t.same(result, [[2]], 'streams')
+  })
+
+  await t.test('diff stream lengths', async (t) => {
+    async function* a() {
+      yield fromJS(1)
+      yield fromJS(3)
+    }
+    async function* b() {
+      yield fromJS(1)
+      yield Promise.resolve(fromJS(2))
+      yield fromJS(4)
+    }
+
+    const streamA = new StreamValue(a)
+    const streamB = new StreamValue(b)
+    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    t.same(result, [[]], 'streams')
+  })
+
+  await t.test('equal stream values', async (t) => {
+    async function* a() {
+      yield fromJS(1)
+      yield Promise.resolve(fromJS(2))
+      yield fromJS(3)
+    }
+    async function* b() {
+      yield fromJS(1)
+      yield Promise.resolve(fromJS(2))
+      yield fromJS(3)
+    }
+
+    const streamA = new StreamValue(a)
+    const streamB = new StreamValue(b)
+    const result = await Array.fromAsync(diffKeyPaths(streamA, streamB))
+    t.same(result, [], 'streams')
   })
 })

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -186,9 +186,86 @@ t.test('Functions', async (t) => {
   })
 
   t.test('diff::changedOnly()', async (t) => {
-    t.test('throws `not implemented` error', async (t) => {
+    t.test('with empty before/after unchanged selector', async (t) => {
       const tree = parse('diff::changedOnly({}, {}, foo)')
-      throwsWithMessage(t, async () => await evaluate(tree, {}), 'not implemented')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with scalar before/after and unchanged selector', async (t) => {
+      const tree = parse('diff::changedOnly(1, 2, foo)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === false, 'result should be `false`')
+    })
+
+    t.test('with unchanged selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1}, {"foo": 1}, foo)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with changed selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1}, {"foo": 2}, foo)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with changed selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": {"bar": 1}}, {"foo": {"bar": 2}}, foo.bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with change not in selector, selector not defined', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1}, {"foo": 2}, bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === false, 'result should be `false`')
+    })
+
+    t.test('with change not in selector, long selector not defined', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1}, {"foo": 2}, foo.bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === false, 'result should be `false`')
+    })
+
+    t.test('with change not in selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1, "bar": 3}, {"foo": 2, "bar": 3}, bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === false, 'result should be `false`')
+    })
+
+    t.test('with change in selector and not in selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1, "bar": 3}, {"foo": 2, "bar": 4}, bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === false, 'result should be `false`')
+    })
+
+    t.test('with change only in selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": 1, "bar": 3}, {"foo": 1, "bar": 4}, bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with change only in nested selector', async (t) => {
+      const tree = parse('diff::changedOnly({"foo": {"bar": 3}}, {"foo": {"bar": 4}}, foo.bar)')
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with change only in tuple selector', async (t) => {
+      const tree = parse(
+        'diff::changedOnly({"foo": {"bar": 3}}, {"foo": {"bar": 4}}, (foo, foo.bar))',
+      )
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
+    })
+
+    t.test('with change in child of tuple selector', async (t) => {
+      const tree = parse(
+        'diff::changedOnly({"foo": {"bar": 3, "baz": 5}}, {"foo": {"bar": 4, "baz": 6}}, (foo, foo.bar))',
+      )
+      const result = await evaluate(tree)
+      t.ok((await result.get()) === true, 'result should be `true`')
     })
   })
 


### PR DESCRIPTION
### Description

This PR enables the diff::changedOnly function

### What to review

Ensure the algorithm matches expectations compared to the current implementation.

### Testing

Added tests for new key path logic as well as tests for changedOnly which were verified against a dataset using the Vision tool.
