### PR TITLE
fix: Handle exceptions during StreamValue fetch

### DIFF
--- a/test/values/StreamValue.test.ts
+++ b/test/values/StreamValue.test.ts
@@ -1,0 +1,27 @@
+import t from 'tap'
+import {StreamValue} from '../../src/values/StreamValue'
+import {fromJS} from '../../src/values'
+
+t.test('StreamValue', async (t) => {
+  t.test('handles exceptions during fetch', async (t) => {
+    const value = new StreamValue(async function* () {
+      throw new Error('test')
+    })
+
+    t.rejects(() => value.get(), 'blah')
+  })
+
+  t.test('returns yielded results', async (t) => {
+    const value = new StreamValue(async function* () {
+      yield fromJS(1)
+      yield fromJS(2)
+      yield fromJS(3)
+    })
+
+    const result = await value.get()
+    t.equal(result.length, 3)
+    t.equal(await result[0], 1)
+    t.equal(await result[1], 2)
+    t.equal(await result[2], 3)
+  })
+})


### PR DESCRIPTION
### Description

If an error is thrown during the execution of the `fetch` function then node will kill the process due to an unhandled rejection. This PR handles the rejection by sending it to the current ticker's promise as a rejection.

### What to review

Ensure StreamValues still work as expected to manage async generators.

### Testing

Added a new test to ensurethe success and failure paths are handled as expected
