### PR TITLE
feat(typeEvaluator): support document::get -> unknown/null

### DIFF
--- a/src/evaluator/functions/documents.ts
+++ b/src/evaluator/functions/documents.ts
@@ -1,0 +1,7 @@
+import type {FunctionSet} from '.'
+
+const documents: FunctionSet = {}
+documents['get'] = () => {
+  throw new Error('not implemented')
+}
+export default documents

--- a/src/evaluator/functions/index.ts
+++ b/src/evaluator/functions/index.ts
@@ -6,6 +6,7 @@ import array from './array'
 import dateTime from './dateTime'
 import delta from './delta'
 import diff from './diff'
+import documents from './documents'
 import geo from './geo'
 import _global from './global'
 import math from './math'
@@ -57,4 +58,5 @@ export const namespaces: NamespaceSet = {
   releases,
   text,
   geo,
+  documents,
 }

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -494,6 +494,20 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
         return {type: 'boolean'}
       })
     }
+    case 'documents.get': {
+      const typeNode = walk({node: node.args[0], scope})
+      return mapNode(typeNode, scope, (typeNode) => {
+        if (typeNode.type === 'unknown') {
+          return typeNode
+        }
+
+        if (typeNode.type !== 'object') {
+          return {type: 'null'}
+        }
+
+        return {type: 'unknown'}
+      })
+    }
     default: {
       return {type: 'unknown'}
     }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -2982,6 +2982,37 @@ t.test('function: geo::*', (t) => {
   t.end()
 })
 
+t.test('function: documents::*', (t) => {
+  const query = `*[_type == "post"] {
+    "name": documents::get(name),
+    "author": documents::get(author),
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
+          value: {
+            type: 'null',
+          },
+        },
+        author: {
+          type: 'objectAttribute',
+          value: {
+            type: 'unknown',
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 t.test('scoping', (t) => {
   const ast = parse(`*[_type == "mainDocument" && _id == $id]{
     _id,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds support for parsing `documents::get` so it doesn't break type evaluation 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
