### PR TITLE
feat: allow parsing missing functions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
 export interface ParseOptions {
   params?: Record<string, unknown>
   mode?: 'normal' | 'delta'
+
+  /**
+   * If true, the parser will allow functions that are not defined in the built-in function sets.
+   * Mainly useful for allowing custom functions to be used in combination with TypeGen.
+   * @internal
+   */
+  allowUnknownFunctions?: boolean
 }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3413,6 +3413,30 @@ t.test('function: sanity::partOfRelease', (t) => {
   t.end()
 })
 
+t.test('function: undefined function', (t) => {
+  const query = `*[]{
+    "something": something::custom()
+  }`
+  const ast = parse(query, {allowUnknownFunctions: true})
+  const res = typeEvaluate(ast, schemas)
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        something: {
+          type: 'objectAttribute',
+          value: {
+            type: 'unknown',
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 t.test('deref inline', (t) => {
   const query = `*[_type == "test"] { field-> { _type } }`
   const ast = parse(query)


### PR DESCRIPTION
### Description

🚨 PSA: View without newlines! 🚨

More of a suggestion: If we allow parsing without checking for function existence, but return a throwing function, we can use this option when parsing queries for typegen.
Currently TypeGen + Custom functions doens't work well together, with this change it still won't work properly, but at least it doesn't break the type evaluation of the entire query. Since it's also during parse we will only enable this for typegen. It's only meant to be a temporary step until we have support for custom functions
