### PR TITLE
feat(parser): add support for parsing and replacing custom functions

### DIFF
--- a/src/markProcessor.ts
+++ b/src/markProcessor.ts
@@ -20,6 +20,7 @@ export type MarkName =
   | 'float'
   | 'func_args_end'
   | 'func_call'
+  | 'func_decl'
   | 'ident'
   | 'inc_range'
   | 'integer'

--- a/src/nodeTypes.ts
+++ b/src/nodeTypes.ts
@@ -1,7 +1,12 @@
 import type {GroqFunction, GroqPipeFunction} from './evaluator/functions'
 
 /** Any sort of node which appears as syntax */
-export type SyntaxNode = ExprNode | ArrayElementNode | ObjectAttributeNode | SelectAlternativeNode
+export type SyntaxNode =
+  | ExprNode
+  | ArrayElementNode
+  | ObjectAttributeNode
+  | SelectAlternativeNode
+  | FunctionDeclarationNode
 
 export type ObjectAttributeNode =
   | ObjectAttributeValueNode
@@ -278,6 +283,14 @@ export interface TupleNode<Base = ExprNode> extends BaseNode {
 export interface ValueNode<P = any> {
   type: 'Value'
   value: P
+}
+
+export interface FunctionDeclarationNode extends BaseNode {
+  type: 'FuncDeclaration'
+  namespace: string
+  name: string
+  params: ParameterNode[]
+  body: ExprNode
 }
 
 export interface FlatMapNode extends BaseNode {

--- a/tap-snapshots/test/parse.test.ts.test.cjs
+++ b/tap-snapshots/test/parse.test.ts.test.cjs
@@ -224,6 +224,113 @@ Object {
 }
 `
 
+exports[`test/parse.test.ts TAP Custom functions can parse > must match snapshot 1`] = `
+Object {
+  "base": Object {
+    "base": Object {
+      "type": "Everything",
+    },
+    "expr": Object {
+      "left": Object {
+        "name": "_type",
+        "type": "AccessAttribute",
+      },
+      "op": "==",
+      "right": Object {
+        "type": "Value",
+        "value": "person",
+      },
+      "type": "OpCall",
+    },
+    "type": "Filter",
+  },
+  "expr": Object {
+    "base": Object {
+      "type": "This",
+    },
+    "expr": Object {
+      "attributes": Array [
+        Object {
+          "name": "info",
+          "type": "ObjectAttributeValue",
+          "value": Object {
+            "base": Object {
+              "type": "This",
+            },
+            "expr": Object {
+              "attributes": Array [
+                Object {
+                  "name": "name",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "name": "name",
+                    "type": "AccessAttribute",
+                  },
+                },
+                Object {
+                  "name": "names",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "base": Object {
+                      "base": Object {
+                        "name": "name",
+                        "type": "AccessAttribute",
+                      },
+                      "type": "ArrayCoerce",
+                    },
+                    "expr": Object {
+                      "base": Object {
+                        "type": "This",
+                      },
+                      "expr": Object {
+                        "attributes": Array [
+                          Object {
+                            "name": "first",
+                            "type": "ObjectAttributeValue",
+                            "value": Object {
+                              "name": "first",
+                              "type": "AccessAttribute",
+                            },
+                          },
+                          Object {
+                            "name": "last",
+                            "type": "ObjectAttributeValue",
+                            "value": Object {
+                              "name": "last",
+                              "type": "AccessAttribute",
+                            },
+                          },
+                        ],
+                        "type": "Object",
+                      },
+                      "type": "Projection",
+                    },
+                    "type": "Map",
+                  },
+                },
+                Object {
+                  "name": "age",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "name": "age",
+                    "type": "AccessAttribute",
+                  },
+                },
+              ],
+              "type": "Object",
+            },
+            "type": "Projection",
+          },
+        },
+      ],
+      "type": "Object",
+    },
+    "type": "Projection",
+  },
+  "type": "Map",
+}
+`
+
 exports[`test/parse.test.ts TAP Expression parsing when extracting property keys can extract from group > must match snapshot 1`] = `
 Object {
   "base": Object {

--- a/test/generate.js
+++ b/test/generate.js
@@ -8,7 +8,12 @@ const fs = require('fs')
 const https = require('https')
 const semver = require('semver')
 
-const SUPPORTED_FEATURES = new Set(['portableText', 'contentReleases', 'internalDocuments'])
+const SUPPORTED_FEATURES = new Set([
+  'portableText',
+  'contentReleases',
+  'internalDocuments',
+  'customFunctions',
+])
 // We implement GROQ-1.revision1. The final patch has to be there for it to be a valid SemVer.
 // E.g. GROQ-1.revision2 maps to 1.2.0
 const GROQ_VERSION = '1.2.0'

--- a/test/generate.sh
+++ b/test/generate.sh
@@ -8,7 +8,7 @@ if [[ "$GROQTEST_SUITE" != "" ]]; then
   echo "Using test suite file: $GROQTEST_SUITE"
   node "$DIR"/generate.js < "$GROQTEST_SUITE" >"$RESULT"
 else
-  GROQTEST_SUITE_VERSION=${GROQTEST_SUITE_VERSION:-v1.0.1}
+  GROQTEST_SUITE_VERSION=${GROQTEST_SUITE_VERSION:-v1.0.2}
   url=https://github.com/sanity-io/groq-test-suite/releases/download/$GROQTEST_SUITE_VERSION/suite.ndjson
   echo "Getting test suite: $url"
   curl -sfL "$url" | node "$DIR"/generate.js >"$RESULT"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Add support for parsing custom functions! Currently it just replaces/inlines the function where it's used, from a typegen perspective it can end up being a lot of repetition, but this is step 1 and we can look into normalizing it later.

### What to review

The parser mainly 😬 

### Testing

Added unit tests, and enabled groq test suite with custom functions 🖖 