### PR TITLE
feat(parser): add support for parsing custom functions

### DIFF
--- a/src/markProcessor.ts
+++ b/src/markProcessor.ts
@@ -1,3 +1,4 @@
+import type {CustomFunctions} from './rawParser'
 import type {ParseOptions} from './types'
 
 export type MarkName =
@@ -20,6 +21,7 @@ export type MarkName =
   | 'float'
   | 'func_args_end'
   | 'func_call'
+  | 'func_decl'
   | 'ident'
   | 'inc_range'
   | 'integer'
@@ -53,19 +55,28 @@ export interface Mark {
   position: number
 }
 
+export type FunctionId = `${string}::${string}`
+
 export type MarkVisitor<T> = Record<string, MarkVisitorFunc<T>>
 export type MarkVisitorFunc<T> = (p: MarkProcessor, mark: Mark) => T
 
 export class MarkProcessor {
-  private string: string
+  private _string: string
   private marks: Mark[]
   private index: number
+  customFunctions: CustomFunctions
   parseOptions: ParseOptions
   allowBoost = false
 
-  constructor(string: string, marks: Mark[], parseOptions: ParseOptions) {
-    this.string = string
+  constructor(
+    string: string,
+    marks: Mark[],
+    customFunctions: CustomFunctions,
+    parseOptions: ParseOptions,
+  ) {
+    this._string = string
     this.marks = marks
+    this.customFunctions = customFunctions
     this.index = 0
     this.parseOptions = parseOptions
   }
@@ -107,5 +118,9 @@ export class MarkProcessor {
   slice(len: number): string {
     const pos = this.marks[this.index].position
     return this.string.slice(pos, pos + len)
+  }
+
+  get string(): string {
+    return this._string
   }
 }

--- a/src/nodeTypes.ts
+++ b/src/nodeTypes.ts
@@ -272,6 +272,14 @@ export interface ValueNode<P = any> {
   value: P
 }
 
+export interface FunctionDeclarationNode {
+  type: 'FuncDeclaration'
+  namespace: string
+  name: string
+  params: ParameterNode[]
+  body: ExprNode
+}
+
 export interface FlatMapNode extends BaseNode {
   type: 'FlatMap'
   base: ExprNode

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,18 +3,20 @@ import {tryConstantEvaluate} from './evaluator'
 import {type GroqFunctionArity, namespaces, pipeFunctions} from './evaluator/functions'
 import {MarkProcessor, type MarkVisitor} from './markProcessor'
 import {
-  isSelectorNested,
   type ArrayElementNode,
   type ExprNode,
   type FuncCallNode,
+  type FunctionDeclarationNode,
+  isSelectorNested,
   type ObjectAttributeNode,
   type ObjectSplatNode,
   type OpCall,
+  type ParameterNode,
   type ParentNode,
   type SelectNode,
   type SelectorNode,
 } from './nodeTypes'
-import {parse as rawParse} from './rawParser'
+import {type CustomFunctions, parse as rawParse} from './rawParser'
 import {
   type TraversalResult,
   traverseArray,
@@ -23,6 +25,7 @@ import {
   traverseProjection,
 } from './traversal'
 import type {ParseOptions} from './types'
+import {walkValidateCustomFunction} from './walk'
 
 type EscapeSequences = "'" | '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't'
 
@@ -49,824 +52,847 @@ class GroqQueryError extends Error {
   public override name = 'GroqQueryError'
 }
 
-const EXPR_BUILDER: MarkVisitor<ExprNode> = {
-  group(p) {
-    const inner = p.process(EXPR_BUILDER)
-    return {
-      type: 'Group',
-      base: inner,
-    }
-  },
-
-  everything() {
-    return {type: 'Everything'}
-  },
-
-  this() {
-    return {type: 'This'}
-  },
-
-  parent() {
-    return {
-      type: 'Parent',
-      n: 1,
-    }
-  },
-
-  dblparent(p) {
-    const next = p.process(EXPR_BUILDER) as ParentNode
-    return {
-      type: 'Parent',
-      n: next.n + 1,
-    }
-  },
-
-  traverse(p) {
-    const base = p.process(EXPR_BUILDER)
-    const traversalList: Array<TraverseFunc> = []
-    while (p.getMark().name !== 'traversal_end') {
-      traversalList.push(p.process(TRAVERSE_BUILDER))
-    }
-    p.shift()
-    let traversal: TraversalResult | null = null
-    for (let i = traversalList.length - 1; i >= 0; i--) {
-      traversal = traversalList[i](traversal)
-    }
-    if (base.type === 'Everything' || base.type === 'Array' || base.type === 'PipeFuncCall') {
-      traversal = traverseArray((val) => val, traversal)
-    }
-    if (traversal === null) throw new Error('BUG: unexpected empty traversal')
-    return traversal.build(base)
-  },
-
-  this_attr(p) {
-    const name = p.processString()
-
-    if (name === 'null') {
-      return {type: 'Value', value: null}
-    }
-    if (name === 'true') {
-      return {type: 'Value', value: true}
-    }
-    if (name === 'false') {
-      return {type: 'Value', value: false}
-    }
-
-    return {
-      type: 'AccessAttribute',
-      name,
-    }
-  },
-
-  neg(p) {
-    const base = p.process(EXPR_BUILDER)
-
-    return {
-      type: 'Neg',
-      base,
-    }
-  },
-
-  pos(p) {
-    const base = p.process(EXPR_BUILDER)
-
-    return {
-      type: 'Pos',
-      base,
-    }
-  },
-
-  add(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '+',
-      left,
-      right,
-    }
-  },
-
-  sub(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '-',
-      left,
-      right,
-    }
-  },
-
-  mul(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '*',
-      left,
-      right,
-    }
-  },
-
-  div(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '/',
-      left,
-      right,
-    }
-  },
-
-  mod(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '%',
-      left,
-      right,
-    }
-  },
-
-  pow(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: '**',
-      left,
-      right,
-    }
-  },
-
-  comp(p) {
-    const left = p.process(EXPR_BUILDER)
-    const op = p.processString() as OpCall
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'OpCall',
-      op: op,
-      left: left,
-      right: right,
-    }
-  },
-
-  in_range(p) {
-    const base = p.process(EXPR_BUILDER)
-    const isInclusive = p.getMark().name === 'inc_range'
-    p.shift()
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'InRange',
-      base,
-      left,
-      right,
-      isInclusive,
-    }
-  },
-
-  str(p) {
-    let value = ''
-    // eslint-disable-next-line no-labels
-    loop: while (p.hasMark()) {
-      const mark = p.getMark()
-      switch (mark.name) {
-        case 'str_end':
-          value += p.processStringEnd()
-          // eslint-disable-next-line no-labels
-          break loop
-        case 'str_pause':
-          value += p.processStringEnd()
-          break
-        case 'str_start':
-          p.shift()
-          break
-        case 'single_escape': {
-          const char = p.slice(1)
-          p.shift()
-          value += ESCAPE_SEQUENCE[char as EscapeSequences]
-          break
-        }
-        case 'unicode_hex':
-          p.shift()
-          value += expandHex(p.processStringEnd())
-          break
-        default:
-          throw new Error(`unexpected mark: ${mark.name}`)
+function createExpressionBuilder(recursion: Set<string> = new Set()): MarkVisitor<ExprNode> {
+  const exprBuilder: MarkVisitor<ExprNode> = {
+    group(p) {
+      const inner = p.process(exprBuilder)
+      return {
+        type: 'Group',
+        base: inner,
       }
-    }
-    return {type: 'Value', value}
-  },
+    },
 
-  integer(p) {
-    const strValue = p.processStringEnd()
-    return {
-      type: 'Value',
-      value: Number(strValue),
-    }
-  },
+    everything() {
+      return {type: 'Everything'}
+    },
 
-  float(p) {
-    const strValue = p.processStringEnd()
-    return {
-      type: 'Value',
-      value: Number(strValue),
-    }
-  },
+    this() {
+      return {type: 'This'}
+    },
 
-  sci(p) {
-    const strValue = p.processStringEnd()
-    return {
-      type: 'Value',
-      value: Number(strValue),
-    }
-  },
-
-  object(p) {
-    const attributes: ObjectAttributeNode[] = []
-    while (p.getMark().name !== 'object_end') {
-      attributes.push(p.process(OBJECT_BUILDER))
-    }
-    p.shift()
-
-    return {
-      type: 'Object',
-      attributes,
-    }
-  },
-
-  array(p) {
-    const elements: ArrayElementNode[] = []
-    while (p.getMark().name !== 'array_end') {
-      let isSplat = false
-      if (p.getMark().name === 'array_splat') {
-        isSplat = true
-        p.shift()
+    parent() {
+      return {
+        type: 'Parent',
+        n: 1,
       }
-      const value = p.process(EXPR_BUILDER)
-      elements.push({
-        type: 'ArrayElement',
-        value,
-        isSplat,
-      })
-    }
-    p.shift()
-    return {
-      type: 'Array',
-      elements: elements,
-    }
-  },
+    },
 
-  tuple(p) {
-    const members: ExprNode[] = []
-    while (p.getMark().name !== 'tuple_end') {
-      members.push(p.process(EXPR_BUILDER))
-    }
-    p.shift()
-    return {
-      type: 'Tuple',
-      members,
-    }
-  },
-
-  func_call(p) {
-    let namespace = 'global'
-    if (p.getMark().name === 'namespace') {
-      p.shift()
-      namespace = p.processString()
-    }
-
-    const name = p.processString()
-    if (namespace === 'global' && name === 'select') {
-      const result: SelectNode = {
-        type: 'Select',
-        alternatives: [],
+    dblparent(p) {
+      const next = p.process(exprBuilder) as ParentNode
+      return {
+        type: 'Parent',
+        n: next.n + 1,
       }
+    },
 
-      while (p.getMark().name !== 'func_args_end') {
-        if (p.getMark().name === 'pair') {
-          if (result.fallback) throw new GroqQueryError(`unexpected argument to select()`)
-          p.shift()
-          const condition = p.process(EXPR_BUILDER)
-          const value = p.process(EXPR_BUILDER)
-          result.alternatives.push({
-            type: 'SelectAlternative',
-            condition,
-            value,
-          })
-        } else {
-          if (result.fallback) throw new GroqQueryError(`unexpected argument to select()`)
-          const value = p.process(EXPR_BUILDER)
-          result.fallback = value
-        }
+    traverse(p) {
+      const base = p.process(exprBuilder)
+      const traversalList: Array<TraverseFunc> = []
+      while (p.getMark().name !== 'traversal_end') {
+        traversalList.push(p.process(TRAVERSE_BUILDER))
       }
       p.shift()
-      return result
-    }
-
-    const args: ExprNode[] = []
-
-    while (p.getMark().name !== 'func_args_end') {
-      if (argumentShouldBeSelector(namespace, name, args.length)) {
-        args.push(p.process(SELECTOR_BUILDER))
-      } else {
-        args.push(p.process(EXPR_BUILDER))
+      let traversal: TraversalResult | null = null
+      for (let i = traversalList.length - 1; i >= 0; i--) {
+        traversal = traversalList[i](traversal)
       }
-    }
-
-    p.shift()
-
-    if (namespace === 'global' && (name === 'before' || name === 'after')) {
-      if (p.parseOptions.mode === 'delta') {
-        return {
-          type: 'Context',
-          key: name,
-        }
+      if (base.type === 'Everything' || base.type === 'Array' || base.type === 'PipeFuncCall') {
+        traversal = traverseArray((val) => val, traversal)
       }
-    }
+      if (traversal === null) throw new Error('BUG: unexpected empty traversal')
+      return traversal.build(base)
+    },
 
-    if (namespace === 'global' && name === 'boost' && !p.allowBoost)
-      throw new GroqQueryError('unexpected boost')
+    this_attr(p) {
+      const name = p.processString()
 
-    const funcs = namespaces[namespace]
-    if (!funcs) {
-      throw new GroqQueryError(`Undefined namespace: ${namespace}`)
-    }
+      if (name === 'null') {
+        return {type: 'Value', value: null}
+      }
+      if (name === 'true') {
+        return {type: 'Value', value: true}
+      }
+      if (name === 'false') {
+        return {type: 'Value', value: false}
+      }
 
-    const func = funcs[name]
-    if (!func) {
-      throw new GroqQueryError(`Undefined function: ${name}`)
-    }
-    if (func.arity !== undefined) {
-      validateArity(name, func.arity, args.length)
-    }
+      return {
+        type: 'AccessAttribute',
+        name,
+      }
+    },
 
-    if (func.mode !== undefined && func.mode !== p.parseOptions.mode) {
-      throw new GroqQueryError(`Undefined function: ${name}`)
-    }
+    neg(p) {
+      const base = p.process(exprBuilder)
 
-    return {
-      type: 'FuncCall',
-      func,
-      namespace,
-      name,
-      args,
-    }
-  },
+      return {
+        type: 'Neg',
+        base,
+      }
+    },
 
-  pipecall(p) {
-    const base = p.process(EXPR_BUILDER)
-    p.shift() // Remove the func_call
+    pos(p) {
+      const base = p.process(exprBuilder)
 
-    let namespace = 'global'
-    if (p.getMark().name === 'namespace') {
+      return {
+        type: 'Pos',
+        base,
+      }
+    },
+
+    add(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '+',
+        left,
+        right,
+      }
+    },
+
+    sub(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '-',
+        left,
+        right,
+      }
+    },
+
+    mul(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '*',
+        left,
+        right,
+      }
+    },
+
+    div(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '/',
+        left,
+        right,
+      }
+    },
+
+    mod(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '%',
+        left,
+        right,
+      }
+    },
+
+    pow(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: '**',
+        left,
+        right,
+      }
+    },
+
+    comp(p) {
+      const left = p.process(exprBuilder)
+      const op = p.processString() as OpCall
+      const right = p.process(exprBuilder)
+      return {
+        type: 'OpCall',
+        op: op,
+        left: left,
+        right: right,
+      }
+    },
+
+    in_range(p) {
+      const base = p.process(exprBuilder)
+      const isInclusive = p.getMark().name === 'inc_range'
       p.shift()
-      namespace = p.processString()
-    }
-    if (namespace !== 'global') {
-      throw new GroqQueryError(`Undefined namespace: ${namespace}`)
-    }
-
-    const name = p.processString()
-    const args: ExprNode[] = []
-
-    const oldAllowBoost = p.allowBoost
-    if (name === 'score') {
-      // Only allow boost inside a score expression
-      p.allowBoost = true
-    }
-
-    for (;;) {
-      const markName = p.getMark().name
-      if (markName === 'func_args_end') {
-        break
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'InRange',
+        base,
+        left,
+        right,
+        isInclusive,
       }
+    },
 
-      if (name === 'order') {
-        if (markName === 'asc') {
-          p.shift()
-          args.push({type: 'Asc', base: p.process(EXPR_BUILDER)})
-          continue
-        } else if (markName === 'desc') {
-          p.shift()
-          args.push({type: 'Desc', base: p.process(EXPR_BUILDER)})
-          continue
+    str(p) {
+      let value = ''
+      // eslint-disable-next-line no-labels
+      loop: while (p.hasMark()) {
+        const mark = p.getMark()
+        switch (mark.name) {
+          case 'str_end':
+            value += p.processStringEnd()
+            // eslint-disable-next-line no-labels
+            break loop
+          case 'str_pause':
+            value += p.processStringEnd()
+            break
+          case 'str_start':
+            p.shift()
+            break
+          case 'single_escape': {
+            const char = p.slice(1)
+            p.shift()
+            value += ESCAPE_SEQUENCE[char as EscapeSequences]
+            break
+          }
+          case 'unicode_hex':
+            p.shift()
+            value += expandHex(p.processStringEnd())
+            break
+          default:
+            throw new Error(`unexpected mark: ${mark.name}`)
         }
       }
+      return {type: 'Value', value}
+    },
 
-      args.push(p.process(EXPR_BUILDER))
-    }
-    p.shift()
-
-    p.allowBoost = oldAllowBoost
-
-    const func = pipeFunctions[name]
-    if (!func) {
-      throw new GroqQueryError(`Undefined pipe function: ${name}`)
-    }
-    if (func.arity) {
-      validateArity(name, func.arity, args.length)
-    }
-
-    return {
-      type: 'PipeFuncCall',
-      func,
-      base,
-      name,
-      args,
-    }
-  },
-
-  pair() {
-    throw new GroqQueryError(`unexpected =>`)
-  },
-
-  and(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'And',
-      left,
-      right,
-    }
-  },
-
-  or(p) {
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-    return {
-      type: 'Or',
-      left,
-      right,
-    }
-  },
-
-  not(p) {
-    const base = p.process(EXPR_BUILDER)
-    return {
-      type: 'Not',
-      base,
-    }
-  },
-
-  asc() {
-    throw new GroqQueryError('unexpected asc')
-  },
-
-  desc() {
-    throw new GroqQueryError('unexpected desc')
-  },
-
-  param(p) {
-    const name = p.processString()
-
-    if (p.parseOptions.params && p.parseOptions.params.hasOwnProperty(name)) {
+    integer(p) {
+      const strValue = p.processStringEnd()
       return {
         type: 'Value',
-        value: p.parseOptions.params[name],
+        value: Number(strValue),
       }
-    }
+    },
 
-    return {
-      type: 'Parameter',
-      name,
-    }
-  },
-}
+    float(p) {
+      const strValue = p.processStringEnd()
+      return {
+        type: 'Value',
+        value: Number(strValue),
+      }
+    },
 
-const OBJECT_BUILDER: MarkVisitor<ObjectAttributeNode> = {
-  object_expr(p) {
-    if (p.getMark().name === 'pair') {
+    sci(p) {
+      const strValue = p.processStringEnd()
+      return {
+        type: 'Value',
+        value: Number(strValue),
+      }
+    },
+
+    object(p) {
+      const attributes: ObjectAttributeNode[] = []
+      while (p.getMark().name !== 'object_end') {
+        attributes.push(p.process(OBJECT_BUILDER))
+      }
       p.shift()
-      const condition = p.process(EXPR_BUILDER)
-      const value = p.process(EXPR_BUILDER)
 
       return {
-        type: 'ObjectConditionalSplat',
-        condition,
+        type: 'Object',
+        attributes,
+      }
+    },
+
+    array(p) {
+      const elements: ArrayElementNode[] = []
+      while (p.getMark().name !== 'array_end') {
+        let isSplat = false
+        if (p.getMark().name === 'array_splat') {
+          isSplat = true
+          p.shift()
+        }
+        const value = p.process(exprBuilder)
+        elements.push({
+          type: 'ArrayElement',
+          value,
+          isSplat,
+        })
+      }
+      p.shift()
+      return {
+        type: 'Array',
+        elements: elements,
+      }
+    },
+
+    tuple(p) {
+      const members: ExprNode[] = []
+      while (p.getMark().name !== 'tuple_end') {
+        members.push(p.process(exprBuilder))
+      }
+      p.shift()
+      return {
+        type: 'Tuple',
+        members,
+      }
+    },
+
+    func_call(p) {
+      let namespace = 'global'
+      if (p.getMark().name === 'namespace') {
+        p.shift()
+        namespace = p.processString()
+      }
+
+      const name = p.processString()
+      if (namespace === 'global' && name === 'select') {
+        const result: SelectNode = {
+          type: 'Select',
+          alternatives: [],
+        }
+
+        while (p.getMark().name !== 'func_args_end') {
+          if (p.getMark().name === 'pair') {
+            if (result.fallback) throw new GroqQueryError(`unexpected argument to select()`)
+            p.shift()
+            const condition = p.process(exprBuilder)
+            const value = p.process(exprBuilder)
+            result.alternatives.push({
+              type: 'SelectAlternative',
+              condition,
+              value,
+            })
+          } else {
+            if (result.fallback) throw new GroqQueryError(`unexpected argument to select()`)
+            const value = p.process(exprBuilder)
+            result.fallback = value
+          }
+        }
+        p.shift()
+        return result
+      }
+
+      const args: ExprNode[] = []
+
+      while (p.getMark().name !== 'func_args_end') {
+        if (argumentShouldBeSelector(namespace, name, args.length)) {
+          args.push(p.process(SELECTOR_BUILDER))
+        } else {
+          args.push(p.process(exprBuilder))
+        }
+      }
+
+      p.shift()
+
+      if (namespace === 'global' && (name === 'before' || name === 'after')) {
+        if (p.parseOptions.mode === 'delta') {
+          return {
+            type: 'Context',
+            key: name,
+          }
+        }
+      }
+
+      if (namespace === 'global' && name === 'boost' && !p.allowBoost)
+        throw new GroqQueryError('unexpected boost')
+
+      const customFunction = p.customFunctions[`${namespace}::${name}`]
+      if (customFunction !== undefined) {
+        const FUNCTION_DECL_BUILDER = createFunctionDeclarationBuilder(recursion)
+
+        const processor = new MarkProcessor(p.string, customFunction.marks, p.customFunctions, {})
+        const funcDecl = processor.process(FUNCTION_DECL_BUILDER)
+        validateArity(name, funcDecl.params.length, args.length)
+        return mapCustomFunction(
+          funcDecl.body,
+          (body) => walkValidateCustomFunction(body),
+          (parameterNode) => resolveFunctionParameter(parameterNode, funcDecl.params, args),
+        )
+      }
+
+      const funcs = namespaces[namespace]
+      if (!funcs) {
+        throw new GroqQueryError(`Undefined namespace: ${namespace}`)
+      }
+
+      const func = funcs[name]
+      if (!func) {
+        throw new GroqQueryError(`Undefined function: ${name}`)
+      }
+      if (func.arity !== undefined) {
+        validateArity(name, func.arity, args.length)
+      }
+
+      if (func.mode !== undefined && func.mode !== p.parseOptions.mode) {
+        throw new GroqQueryError(`Undefined function: ${name}`)
+      }
+
+      return {
+        type: 'FuncCall',
+        namespace,
+        name,
+        args,
+        func,
+      }
+    },
+
+    pipecall(p) {
+      const base = p.process(exprBuilder)
+      p.shift() // Remove the func_call
+
+      let namespace = 'global'
+      if (p.getMark().name === 'namespace') {
+        p.shift()
+        namespace = p.processString()
+      }
+      if (namespace !== 'global') {
+        throw new GroqQueryError(`Undefined namespace: ${namespace}`)
+      }
+
+      const name = p.processString()
+      const args: ExprNode[] = []
+
+      const oldAllowBoost = p.allowBoost
+      if (name === 'score') {
+        // Only allow boost inside a score expression
+        p.allowBoost = true
+      }
+
+      for (;;) {
+        const markName = p.getMark().name
+        if (markName === 'func_args_end') {
+          break
+        }
+
+        if (name === 'order') {
+          if (markName === 'asc') {
+            p.shift()
+            args.push({type: 'Asc', base: p.process(exprBuilder)})
+            continue
+          } else if (markName === 'desc') {
+            p.shift()
+            args.push({type: 'Desc', base: p.process(exprBuilder)})
+            continue
+          }
+        }
+
+        args.push(p.process(exprBuilder))
+      }
+      p.shift()
+
+      p.allowBoost = oldAllowBoost
+
+      const func = pipeFunctions[name]
+      if (!func) {
+        throw new GroqQueryError(`Undefined pipe function: ${name}`)
+      }
+      if (func.arity) {
+        validateArity(name, func.arity, args.length)
+      }
+
+      return {
+        type: 'PipeFuncCall',
+        func,
+        base,
+        name,
+        args,
+      }
+    },
+
+    pair() {
+      throw new GroqQueryError(`unexpected =>`)
+    },
+
+    and(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'And',
+        left,
+        right,
+      }
+    },
+
+    or(p) {
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+      return {
+        type: 'Or',
+        left,
+        right,
+      }
+    },
+
+    not(p) {
+      const base = p.process(exprBuilder)
+      return {
+        type: 'Not',
+        base,
+      }
+    },
+
+    asc() {
+      throw new GroqQueryError('unexpected asc')
+    },
+
+    desc() {
+      throw new GroqQueryError('unexpected desc')
+    },
+
+    param(p) {
+      const name = p.processString()
+
+      if (p.parseOptions.params && p.parseOptions.params.hasOwnProperty(name)) {
+        return {
+          type: 'Value',
+          value: p.parseOptions.params[name],
+        }
+      }
+
+      return {
+        type: 'Parameter',
+        name,
+      }
+    },
+  }
+
+  const OBJECT_BUILDER: MarkVisitor<ObjectAttributeNode> = {
+    object_expr(p) {
+      if (p.getMark().name === 'pair') {
+        p.shift()
+        const condition = p.process(exprBuilder)
+        const value = p.process(exprBuilder)
+
+        return {
+          type: 'ObjectConditionalSplat',
+          condition,
+          value,
+        }
+      }
+
+      const value = p.process(exprBuilder)
+
+      return {
+        type: 'ObjectAttributeValue',
+        name: extractPropertyKey(value),
         value,
       }
-    }
+    },
 
-    const value = p.process(EXPR_BUILDER)
+    object_pair(p) {
+      const name = p.process(exprBuilder)
+      if (name.type !== 'Value') throw new Error('name must be string')
 
-    return {
-      type: 'ObjectAttributeValue',
-      name: extractPropertyKey(value),
-      value,
-    }
-  },
-
-  object_pair(p) {
-    const name = p.process(EXPR_BUILDER)
-    if (name.type !== 'Value') throw new Error('name must be string')
-
-    const value = p.process(EXPR_BUILDER)
-    return {
-      type: 'ObjectAttributeValue',
-      name: name.value,
-      value: value,
-    }
-  },
-
-  object_splat(p): ObjectSplatNode {
-    const value = p.process(EXPR_BUILDER)
-
-    return {
-      type: 'ObjectSplat',
-      value,
-    }
-  },
-
-  object_splat_this(): ObjectSplatNode {
-    return {
-      type: 'ObjectSplat',
-      value: {type: 'This'},
-    }
-  },
-}
-
-const TRAVERSE_BUILDER: MarkVisitor<TraverseFunc> = {
-  square_bracket(p) {
-    const expr = p.process(EXPR_BUILDER)
-
-    const value = tryConstantEvaluate(expr)
-    if (value && value.type === 'number') {
-      return (right) =>
-        traverseElement((base) => ({type: 'AccessElement', base, index: value.data}), right)
-    }
-
-    if (value && value.type === 'string') {
-      return (right) =>
-        traversePlain((base) => ({type: 'AccessAttribute', base, name: value.data}), right)
-    }
-
-    return (right) =>
-      traverseArray(
-        (base) => ({
-          type: 'Filter',
-          base,
-          expr,
-        }),
-        right,
-      )
-  },
-
-  slice(p) {
-    const isInclusive = p.getMark().name === 'inc_range'
-    p.shift()
-
-    const left = p.process(EXPR_BUILDER)
-    const right = p.process(EXPR_BUILDER)
-
-    const leftValue = tryConstantEvaluate(left)
-    const rightValue = tryConstantEvaluate(right)
-
-    if (!leftValue || !rightValue || leftValue.type !== 'number' || rightValue.type !== 'number') {
-      throw new GroqQueryError('slicing must use constant numbers')
-    }
-
-    return (rhs) =>
-      traverseArray(
-        (base) => ({
-          type: 'Slice',
-          base,
-          left: leftValue.data,
-          right: rightValue.data,
-          isInclusive,
-        }),
-        rhs,
-      )
-  },
-
-  projection(p) {
-    const obj = p.process(EXPR_BUILDER)
-    return (right) =>
-      traverseProjection((base) => ({type: 'Projection', base: base, expr: obj}), right)
-  },
-
-  attr_access(p) {
-    const name = p.processString()
-
-    return (right) => traversePlain((base) => ({type: 'AccessAttribute', base, name}), right)
-  },
-
-  deref(p) {
-    let attr: string | null = null
-
-    if (p.getMark().name === 'deref_attr') {
-      p.shift()
-      attr = p.processString()
-    }
-
-    const wrap = (base: ExprNode): ExprNode =>
-      attr ? {type: 'AccessAttribute', base, name: attr} : base
-
-    return (right) =>
-      traversePlain(
-        (base) =>
-          wrap({
-            type: 'Deref',
-            base,
-          }),
-        right,
-      )
-  },
-
-  array_postfix() {
-    return (right) => traverseArray((base) => ({type: 'ArrayCoerce', base}), right)
-  },
-}
-
-const SELECTOR_BUILDER: MarkVisitor<SelectorNode> = {
-  group(p) {
-    return p.process(SELECTOR_BUILDER)
-  },
-
-  everything() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  this() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  parent() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  dblparent() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  traverse(p) {
-    let node: SelectorNode = p.process(SELECTOR_BUILDER)
-    while (p.getMark().name !== 'traversal_end') {
-      if (p.getMark().name === 'array_postfix') {
-        p.shift()
-
-        node = {type: 'ArrayCoerce', base: node}
-      } else if (p.getMark().name === 'square_bracket') {
-        p.shift()
-
-        const expr = p.process(EXPR_BUILDER)
-
-        const value = tryConstantEvaluate(expr)
-        if (value && value.type === 'number') {
-          throw new Error('Invalid array access expression')
-        } else if (value && value.type === 'string') {
-          node = {type: 'AccessAttribute', base: node, name: value.data}
-        } else {
-          node = {type: 'Filter', base: node, expr}
-        }
-      } else if (p.getMark().name === 'attr_access') {
-        p.shift()
-        const name = p.processString()
-        node = {type: 'AccessAttribute', base: node, name}
-      } else if (p.getMark().name === 'tuple' || p.getMark().name === 'group') {
-        const selector = p.process(SELECTOR_BUILDER)
-        if (!isSelectorNested(selector))
-          throw new Error(`Unexpected result parsing nested selector: ${selector.type}`)
-        node = {type: 'SelectorNested', base: node, nested: selector}
-      } else {
-        throw new Error('Invalid selector syntax')
-      }
-    }
-    p.shift()
-    return node
-  },
-
-  this_attr(p) {
-    const name = p.processString()
-    return {type: 'AccessAttribute', name}
-  },
-
-  attr_access() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  neg() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  pos() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  add() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  sub() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  mul() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  div() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  mod() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  pow() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  comp() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  in_range() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  str() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  integer() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  float() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  sci() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  object() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  array() {
-    throw new Error('Invalid selector syntax')
-  },
-
-  tuple(p) {
-    const selectors: Array<SelectorNode> = []
-    while (p.getMark().name !== 'tuple_end') {
-      selectors.push(p.process(SELECTOR_BUILDER))
-    }
-    p.shift()
-
-    return {type: 'Tuple', members: selectors}
-  },
-
-  func_call(p, mark) {
-    const func = EXPR_BUILDER['func_call'](p, mark) as FuncCallNode
-    if (func.name === 'anywhere' && func.args.length === 1) {
+      const value = p.process(exprBuilder)
       return {
-        type: 'SelectorFuncCall',
-        name: 'anywhere',
-        arg: func.args[0],
+        type: 'ObjectAttributeValue',
+        name: name.value,
+        value: value,
       }
-    }
+    },
 
-    throw new Error('Invalid selector syntax')
-  },
+    object_splat(p): ObjectSplatNode {
+      const value = p.process(exprBuilder)
 
-  pipecall() {
-    throw new Error('Invalid selector syntax')
-  },
+      return {
+        type: 'ObjectSplat',
+        value,
+      }
+    },
 
-  pair() {
-    throw new Error('Invalid selector syntax')
-  },
+    object_splat_this(): ObjectSplatNode {
+      return {
+        type: 'ObjectSplat',
+        value: {type: 'This'},
+      }
+    },
+  }
 
-  and() {
-    throw new Error('Invalid selector syntax')
-  },
+  const TRAVERSE_BUILDER: MarkVisitor<TraverseFunc> = {
+    square_bracket(p) {
+      const expr = p.process(exprBuilder)
 
-  or() {
-    throw new Error('Invalid selector syntax')
-  },
+      const value = tryConstantEvaluate(expr)
+      if (value && value.type === 'number') {
+        return (right) =>
+          traverseElement((base) => ({type: 'AccessElement', base, index: value.data}), right)
+      }
 
-  not() {
-    throw new Error('Invalid selector syntax')
-  },
+      if (value && value.type === 'string') {
+        return (right) =>
+          traversePlain((base) => ({type: 'AccessAttribute', base, name: value.data}), right)
+      }
 
-  asc() {
-    throw new Error('Invalid selector syntax')
-  },
+      return (right) =>
+        traverseArray(
+          (base) => ({
+            type: 'Filter',
+            base,
+            expr,
+          }),
+          right,
+        )
+    },
 
-  desc() {
-    throw new Error('Invalid selector syntax')
-  },
+    slice(p) {
+      const isInclusive = p.getMark().name === 'inc_range'
+      p.shift()
 
-  param() {
-    throw new Error('Invalid selector syntax')
-  },
+      const left = p.process(exprBuilder)
+      const right = p.process(exprBuilder)
+
+      const leftValue = tryConstantEvaluate(left)
+      const rightValue = tryConstantEvaluate(right)
+
+      if (
+        !leftValue ||
+        !rightValue ||
+        leftValue.type !== 'number' ||
+        rightValue.type !== 'number'
+      ) {
+        throw new GroqQueryError('slicing must use constant numbers')
+      }
+
+      return (rhs) =>
+        traverseArray(
+          (base) => ({
+            type: 'Slice',
+            base,
+            left: leftValue.data,
+            right: rightValue.data,
+            isInclusive,
+          }),
+          rhs,
+        )
+    },
+
+    projection(p) {
+      const obj = p.process(exprBuilder)
+      return (right) =>
+        traverseProjection((base) => ({type: 'Projection', base: base, expr: obj}), right)
+    },
+
+    attr_access(p) {
+      const name = p.processString()
+
+      return (right) => traversePlain((base) => ({type: 'AccessAttribute', base, name}), right)
+    },
+
+    deref(p) {
+      let attr: string | null = null
+
+      if (p.getMark().name === 'deref_attr') {
+        p.shift()
+        attr = p.processString()
+      }
+
+      const wrap = (base: ExprNode): ExprNode =>
+        attr ? {type: 'AccessAttribute', base, name: attr} : base
+
+      return (right) =>
+        traversePlain(
+          (base) =>
+            wrap({
+              type: 'Deref',
+              base,
+            }),
+          right,
+        )
+    },
+
+    array_postfix() {
+      return (right) => traverseArray((base) => ({type: 'ArrayCoerce', base}), right)
+    },
+  }
+
+  const SELECTOR_BUILDER: MarkVisitor<SelectorNode> = {
+    group(p) {
+      return p.process(SELECTOR_BUILDER)
+    },
+
+    everything() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    this() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    parent() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    dblparent() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    traverse(p) {
+      let node: SelectorNode = p.process(SELECTOR_BUILDER)
+      while (p.getMark().name !== 'traversal_end') {
+        if (p.getMark().name === 'array_postfix') {
+          p.shift()
+
+          node = {type: 'ArrayCoerce', base: node}
+        } else if (p.getMark().name === 'square_bracket') {
+          p.shift()
+
+          const expr = p.process(exprBuilder)
+
+          const value = tryConstantEvaluate(expr)
+          if (value && value.type === 'number') {
+            throw new Error('Invalid array access expression')
+          } else if (value && value.type === 'string') {
+            node = {type: 'AccessAttribute', base: node, name: value.data}
+          } else {
+            node = {type: 'Filter', base: node, expr}
+          }
+        } else if (p.getMark().name === 'attr_access') {
+          p.shift()
+          const name = p.processString()
+          node = {type: 'AccessAttribute', base: node, name}
+        } else if (p.getMark().name === 'tuple' || p.getMark().name === 'group') {
+          const selector = p.process(SELECTOR_BUILDER)
+          if (!isSelectorNested(selector))
+            throw new Error(`Unexpected result parsing nested selector: ${selector.type}`)
+          node = {type: 'SelectorNested', base: node, nested: selector}
+        } else {
+          throw new Error('Invalid selector syntax')
+        }
+      }
+      p.shift()
+      return node
+    },
+
+    this_attr(p) {
+      const name = p.processString()
+      return {type: 'AccessAttribute', name}
+    },
+
+    attr_access() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    neg() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    pos() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    add() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    sub() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    mul() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    div() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    mod() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    pow() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    comp() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    in_range() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    str() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    integer() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    float() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    sci() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    object() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    array() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    tuple(p) {
+      const selectors: Array<SelectorNode> = []
+      while (p.getMark().name !== 'tuple_end') {
+        selectors.push(p.process(SELECTOR_BUILDER))
+      }
+      p.shift()
+
+      return {type: 'Tuple', members: selectors}
+    },
+
+    func_call(p, mark) {
+      const func = exprBuilder['func_call'](p, mark) as FuncCallNode
+      if (func.name === 'anywhere' && func.args.length === 1) {
+        return {
+          type: 'SelectorFuncCall',
+          name: 'anywhere',
+          arg: func.args[0],
+        }
+      }
+
+      throw new Error('Invalid selector syntax')
+    },
+
+    pipecall() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    pair() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    and() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    or() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    not() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    asc() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    desc() {
+      throw new Error('Invalid selector syntax')
+    },
+
+    param() {
+      throw new Error('Invalid selector syntax')
+    },
+  }
+
+  return exprBuilder
 }
 
 function extractPropertyKey(node: ExprNode): string {
@@ -905,6 +931,69 @@ function validateArity(name: string, arity: GroqFunctionArity, count: number) {
   }
 }
 
+function resolveFunctionParameter(parameter: ExprNode, params: ParameterNode[], args: ExprNode[]) {
+  if (parameter.type !== 'Parameter') {
+    throw new GroqQueryError(`Expected parameter node, got ${parameter.type}`)
+  }
+  const index = params.findIndex((p) => p.name === parameter.name)
+  if (index === -1) {
+    throw new GroqQueryError(`Missing argument for parameter ${parameter.name} in function call`)
+  }
+  return args[index]
+}
+
+/**
+ * The function body is one of the forms:
+ * - $param{…}
+ * - $param->{…}
+ * - $param[]{…}
+ * - $param[]->{…}
+ *
+ * https://github.com/sanity-io/go-groq/blob/b7fb57f5aefe080becff9e3522c0b7b52a79ffd0/parser/internal/parserv2/parser.go#L975-L981
+ */
+function mapCustomFunction(
+  body: ExprNode,
+  bodyMapper: (body: ExprNode) => ExprNode,
+  parameterMapper: (body: ParameterNode) => ExprNode = (n) => n,
+): ExprNode {
+  if (body.type === 'Projection') {
+    if (body.base.type === 'Parameter') {
+      return {
+        type: 'Projection',
+        base: parameterMapper(body.base),
+        expr: bodyMapper(body.expr),
+      }
+    }
+
+    if (body.base.type === 'Deref') {
+      if (body.base.base.type === 'Parameter') {
+        return {
+          type: 'Projection',
+          base: {
+            type: 'Deref',
+            base: parameterMapper(body.base.base),
+          },
+          expr: bodyMapper(body.expr),
+        }
+      }
+    }
+  }
+
+  if (body.type === 'Map' && body.base.type === 'ArrayCoerce') {
+    if (body.base.base.type === 'Parameter') {
+      return {
+        type: 'Map',
+        base: {
+          type: 'ArrayCoerce',
+          base: parameterMapper(body.base.base),
+        },
+        expr: bodyMapper(body.expr),
+      }
+    }
+  }
+  throw new GroqQueryError(`Unexpected function body, must be a projection. Got "${body.type}"`)
+}
+
 function argumentShouldBeSelector(namespace: string, functionName: string, argCount: number) {
   const functionsRequiringSelectors = ['changedAny', 'changedOnly']
 
@@ -916,7 +1005,7 @@ class GroqSyntaxError extends Error {
   public override name = 'GroqSyntaxError'
 
   constructor(position: number, detail: string) {
-    super(`Syntax error in GROQ query at position ${position}${detail ? ': ' + detail : ''}`)
+    super(`Syntax error in GROQ query at position ${position}${detail ? `: ${detail}` : ''}`)
     this.position = position
   }
 }
@@ -929,6 +1018,60 @@ export function parse(input: string, options: ParseOptions = {}): ExprNode {
   if (result.type === 'error') {
     throw new GroqSyntaxError(result.position, result.message)
   }
-  const processor = new MarkProcessor(input, result.marks, options)
-  return processor.process(EXPR_BUILDER)
+  validateCustomFunctions(input, result.customFunctions)
+
+  const processor = new MarkProcessor(input, result.marks, result.customFunctions, options)
+  const exprBuilder = createExpressionBuilder()
+  return processor.process(exprBuilder)
+}
+
+function createFunctionDeclarationBuilder(
+  recursion: Set<string> = new Set(),
+): MarkVisitor<FunctionDeclarationNode> {
+  return {
+    func_decl(p) {
+      const namespace = p.processString()
+      const name = p.processString()
+      const functionId: string = `${namespace}::${name}`
+      if (recursion.has(functionId)) {
+        throw new GroqQueryError(`Recursive function definition detected for ${functionId}`)
+      }
+
+      const exprBuilder = createExpressionBuilder(new Set([...recursion, functionId]))
+
+      const params: ParameterNode[] = []
+      while (p.getMark().name !== 'func_params_end') {
+        const param = p.process(exprBuilder)
+        if (param.type !== 'Parameter') throw new Error('expected parameter')
+        params.push(param)
+      }
+
+      if (params.length !== 1) {
+        throw new GroqQueryError('Custom functions can only have one parameter')
+      }
+
+      p.shift() // func_params_end
+
+      const body = p.process(exprBuilder)
+
+      return {
+        type: 'FuncDeclaration',
+        namespace,
+        name,
+        params,
+        body,
+      } satisfies FunctionDeclarationNode
+    },
+  } satisfies MarkVisitor<FunctionDeclarationNode>
+}
+function validateCustomFunctions(query: string, customFunctions: CustomFunctions) {
+  for (const functionId in customFunctions) {
+    if (!customFunctions.hasOwnProperty(functionId)) continue
+    const customFunction = customFunctions[functionId]
+    const processor = new MarkProcessor(query, customFunction.marks, customFunctions, {})
+
+    const FUNCTION_DECL_BUILDER = createFunctionDeclarationBuilder()
+    const funcDecl = processor.process(FUNCTION_DECL_BUILDER)
+    mapCustomFunction(funcDecl.body, (body) => walkValidateCustomFunction(body))
+  }
 }

--- a/src/rawParser.d.ts
+++ b/src/rawParser.d.ts
@@ -4,11 +4,18 @@ export type Mark = {
   name: string
   position: number
 }
+export type CustomFunctions = Record<
+  string,
+  {
+    marks: Mark[]
+  }
+>
 
 export declare function parse(input: string):
   | {
       type: 'success'
       marks: Mark[]
+      customFunctions: CustomFunctions
     }
   | {
       type: 'error'

--- a/src/rawParser.js
+++ b/src/rawParser.js
@@ -25,9 +25,22 @@ const PREC_NEG = 8
 function parse(str) {
   let pos = 0
   pos = skipWS(str, pos)
+
+  let customFunctions = {}
+
+  // Parse function declarations first
+  while (pos < str.length && str.substring(pos, pos + 2) === 'fn') {
+    let funcResult = parseFunctionDeclaration(str, pos)
+    if (funcResult.type === 'error') return funcResult
+    customFunctions[`${funcResult.namespace}::${funcResult.name}`] = funcResult
+    pos = skipWS(str, funcResult.position)
+  }
+
+  // Parse the main query expression
   let result = parseExpr(str, pos, 0)
   if (result.type === 'error') return result
   pos = skipWS(str, result.position)
+
   if (pos !== str.length) {
     if (result.failPosition) {
       pos = result.failPosition - 1
@@ -36,6 +49,7 @@ function parse(str) {
   }
   delete result.position
   delete result.failPosition
+  result.customFunctions = customFunctions
   return result
 }
 
@@ -829,6 +843,117 @@ function parseRegex(str, pos, re) {
 function parseRegexStr(str, pos, re) {
   let m = re.exec(str.slice(pos))
   return m ? m[0] : null
+}
+
+/**
+ * Parses a function declaration: fn namespace::name(params) = body;
+ */
+function parseFunctionDeclaration(str, startPos) {
+  let pos = startPos
+  let marks = []
+  let namespace = ''
+  let name = ''
+
+  // Parse "fn"
+  if (str.substring(pos, pos + 2) !== 'fn') {
+    return {
+      type: 'success',
+      position: pos,
+      marks: marks,
+    }
+  }
+  marks.push({name: 'func_decl', position: startPos})
+
+  pos = skipWS(str, pos + 2)
+
+  let identStart = pos
+  namespace = parseRegexStr(str, pos, IDENT)
+  if (!namespace) {
+    return {type: 'error', message: 'Expected function name', position: pos}
+  }
+  marks.push(
+    {name: 'ident', position: identStart},
+    {name: 'ident_end', position: pos + namespace.length},
+  )
+  pos = skipWS(str, pos + namespace.length)
+
+  // Check for "::"
+  if (str.substring(pos, pos + 2) !== '::') {
+    return {type: 'error', message: 'Expected "::" after namespace', position: pos}
+  }
+
+  pos = skipWS(str, pos + 2)
+  name = parseRegexStr(str, pos, IDENT)
+  if (!name) {
+    return {type: 'error', message: 'Expected function name', position: pos}
+  }
+  marks.push({name: 'ident', position: pos}, {name: 'ident_end', position: pos + name.length})
+  pos = skipWS(str, pos + name.length)
+
+  if (str[pos] !== '(') {
+    return {type: 'error', message: 'Expected "("', position: pos}
+  }
+  pos = skipWS(str, pos + 1)
+
+  // Parse parameters
+  while (pos < str.length && str[pos] !== ')') {
+    // Parse parameter (should start with $)
+    if (str[pos] !== '$') {
+      return {type: 'error', message: 'Parameter should start with "$"', position: pos}
+    }
+    const startPos = pos
+    pos++
+
+    const paramName = parseRegexStr(str, pos, IDENT)
+    if (!paramName) {
+      return {type: 'error', message: 'Expected function name', position: pos}
+    }
+    pos += paramName.length
+    marks.push(
+      {name: 'param', position: startPos},
+      {name: 'ident', position: startPos + 1},
+      {name: 'ident_end', position: pos},
+    )
+    pos = skipWS(str, pos)
+
+    // Check for comma
+    if (str[pos] === ',') {
+      pos = skipWS(str, pos + 1)
+    } else if (str[pos] !== ')') {
+      return {type: 'error', message: 'Expected "," or ")"', position: pos}
+    }
+  }
+
+  if (str[pos] !== ')') {
+    return {type: 'error', message: 'Expected ")"', position: pos}
+  }
+  marks.push({name: 'func_params_end', position: pos})
+  pos = skipWS(str, pos + 1)
+
+  if (str[pos] !== '=') {
+    return {type: 'error', message: 'Expected "="', position: pos}
+  }
+  pos = skipWS(str, pos + 1)
+
+  // Parse function body (expression)
+  let bodyResult = parseExpr(str, pos, 0)
+  if (bodyResult.type === 'error') return bodyResult
+  marks = marks.concat(bodyResult.marks)
+  pos = skipWS(str, bodyResult.position)
+
+  // Parse ";"
+  if (str[pos] !== ';') {
+    return {type: 'error', message: 'Expected ";" after function declaration', position: pos}
+  }
+  pos++
+
+  return {
+    type: 'success',
+    position: pos,
+    marks: marks,
+    namespace,
+    name,
+  }
 }
 
 export {parse}

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,0 +1,179 @@
+import {type ExprNode, type SelectorNode} from './nodeTypes'
+
+// eslint-disable-next-line complexity
+export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
+  node: T,
+  level: number = 0,
+): T {
+  switch (node.type) {
+    case 'Projection': {
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+        expr: walkValidateCustomFunction(node.expr, level + 1),
+      }
+    }
+    case 'Filter': {
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+        expr: walkValidateCustomFunction(node.expr, level + 1),
+      }
+    }
+    case 'Parent': {
+      if (level - node.n < 0) {
+        throw new Error(
+          `Invalid use of parent operator (^). No parent n ${node.n} at level ${level}.`,
+        )
+      }
+      return node
+    }
+    case 'Parameter': {
+      throw new Error(
+        `Function parameters are not allowed outside function declarations: ${node.name}`,
+      )
+    }
+
+    case 'Array':
+      return {
+        ...node,
+        elements: node.elements.map((el) => ({
+          ...el,
+          value: walkValidateCustomFunction(el.value, level),
+        })),
+      }
+    case 'PipeFuncCall': {
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+        args: node.args.map((arg) => walkValidateCustomFunction(arg, level)),
+      }
+    }
+
+    case 'Object':
+      return {
+        ...node,
+        attributes: node.attributes.map((attr) => {
+          switch (attr.type) {
+            case 'ObjectAttributeValue':
+              return {
+                ...attr,
+                value: walkValidateCustomFunction(attr.value, level),
+              }
+            case 'ObjectConditionalSplat':
+              return {
+                ...attr,
+                condition: walkValidateCustomFunction(attr.condition, level),
+                value: walkValidateCustomFunction(attr.value, level),
+              }
+            case 'ObjectSplat':
+              return {
+                ...attr,
+                value: walkValidateCustomFunction(attr.value, level),
+              }
+            default:
+              return attr
+          }
+        }),
+      }
+
+    case 'FlatMap':
+    case 'Map': {
+      return {
+        ...node,
+        expr: walkValidateCustomFunction(node.expr, level),
+        base: walkValidateCustomFunction(node.base, level),
+      }
+    }
+    case 'FuncCall': {
+      return {
+        ...node,
+        args: node.args.map((arg) => walkValidateCustomFunction(arg, level)),
+      }
+    }
+    case 'Tuple': {
+      return {
+        ...node,
+        members: node.members.map((member) => walkValidateCustomFunction(member, level)),
+      }
+    }
+
+    case 'Select': {
+      const alternatives = node.alternatives.map((alt) => ({
+        ...alt,
+        condition: walkValidateCustomFunction(alt.condition, level),
+        value: walkValidateCustomFunction(alt.value, level),
+      }))
+      if (node.fallback) {
+        return {
+          ...node,
+          alternatives,
+          fallback: walkValidateCustomFunction(node.fallback, level),
+        }
+      }
+      return {
+        ...node,
+        alternatives,
+      }
+    }
+    case 'SelectorNested':
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+        nested: walkValidateCustomFunction(node.nested, level),
+      }
+    case 'SelectorFuncCall':
+      return {
+        ...node,
+        arg: walkValidateCustomFunction(node.arg, level),
+      }
+
+    case 'AccessAttribute':
+    case 'AccessElement':
+    case 'ArrayCoerce':
+    case 'Asc':
+    case 'Desc':
+    case 'Deref':
+    case 'Group':
+    case 'Neg':
+    case 'Not':
+    case 'Slice':
+    case 'Pos': {
+      if (!node.base) {
+        return node
+      }
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+      }
+    }
+
+    case 'InRange':
+      return {
+        ...node,
+        base: walkValidateCustomFunction(node.base, level),
+        left: walkValidateCustomFunction(node.left, level),
+        right: walkValidateCustomFunction(node.right, level),
+      }
+    case 'OpCall':
+    case 'And':
+    case 'Or':
+      return {
+        ...node,
+        left: walkValidateCustomFunction(node.left, level),
+        right: walkValidateCustomFunction(node.right, level),
+      }
+
+    case 'Everything':
+    case 'This':
+    case 'Value':
+    case 'Context': {
+      return node
+    }
+
+    default: {
+      // @ts-expect-error - we want to ensure we handle all node types
+      throw new Error(`Handle all cases: ${node.type}`)
+    }
+  }
+}

--- a/tap-snapshots/test/parse.test.ts.test.cjs
+++ b/tap-snapshots/test/parse.test.ts.test.cjs
@@ -224,6 +224,113 @@ Object {
 }
 `
 
+exports[`test/parse.test.ts TAP Custom functions can parse > must match snapshot 1`] = `
+Object {
+  "base": Object {
+    "base": Object {
+      "type": "Everything",
+    },
+    "expr": Object {
+      "left": Object {
+        "name": "_type",
+        "type": "AccessAttribute",
+      },
+      "op": "==",
+      "right": Object {
+        "type": "Value",
+        "value": "person",
+      },
+      "type": "OpCall",
+    },
+    "type": "Filter",
+  },
+  "expr": Object {
+    "base": Object {
+      "type": "This",
+    },
+    "expr": Object {
+      "attributes": Array [
+        Object {
+          "name": "info",
+          "type": "ObjectAttributeValue",
+          "value": Object {
+            "base": Object {
+              "type": "This",
+            },
+            "expr": Object {
+              "attributes": Array [
+                Object {
+                  "name": "name",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "name": "name",
+                    "type": "AccessAttribute",
+                  },
+                },
+                Object {
+                  "name": "names",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "base": Object {
+                      "base": Object {
+                        "name": "name",
+                        "type": "AccessAttribute",
+                      },
+                      "type": "ArrayCoerce",
+                    },
+                    "expr": Object {
+                      "base": Object {
+                        "type": "This",
+                      },
+                      "expr": Object {
+                        "attributes": Array [
+                          Object {
+                            "name": "first",
+                            "type": "ObjectAttributeValue",
+                            "value": Object {
+                              "name": "first",
+                              "type": "AccessAttribute",
+                            },
+                          },
+                          Object {
+                            "name": "last",
+                            "type": "ObjectAttributeValue",
+                            "value": Object {
+                              "name": "last",
+                              "type": "AccessAttribute",
+                            },
+                          },
+                        ],
+                        "type": "Object",
+                      },
+                      "type": "Projection",
+                    },
+                    "type": "Map",
+                  },
+                },
+                Object {
+                  "name": "age",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "name": "age",
+                    "type": "AccessAttribute",
+                  },
+                },
+              ],
+              "type": "Object",
+            },
+            "type": "Projection",
+          },
+        },
+      ],
+      "type": "Object",
+    },
+    "type": "Projection",
+  },
+  "type": "Map",
+}
+`
+
 exports[`test/parse.test.ts TAP Expression parsing when extracting property keys can extract from group > must match snapshot 1`] = `
 Object {
   "base": Object {

--- a/test/generate.js
+++ b/test/generate.js
@@ -8,7 +8,12 @@ const fs = require('fs')
 const https = require('https')
 const semver = require('semver')
 
-const SUPPORTED_FEATURES = new Set(['portableText', 'contentReleases', 'internalDocuments'])
+const SUPPORTED_FEATURES = new Set([
+  'portableText',
+  'contentReleases',
+  'internalDocuments',
+  'customFunctions',
+])
 // We implement GROQ-1.revision1. The final patch has to be there for it to be a valid SemVer.
 // E.g. GROQ-1.revision2 maps to 1.2.0
 const GROQ_VERSION = '1.2.0'

--- a/test/generate.sh
+++ b/test/generate.sh
@@ -8,7 +8,7 @@ if [[ "$GROQTEST_SUITE" != "" ]]; then
   echo "Using test suite file: $GROQTEST_SUITE"
   node "$DIR"/generate.js < "$GROQTEST_SUITE" >"$RESULT"
 else
-  GROQTEST_SUITE_VERSION=${GROQTEST_SUITE_VERSION:-v1.0.1}
+  GROQTEST_SUITE_VERSION=${GROQTEST_SUITE_VERSION:-v1.0.2}
   url=https://github.com/sanity-io/groq-test-suite/releases/download/$GROQTEST_SUITE_VERSION/suite.ndjson
   echo "Getting test suite: $url"
   curl -sfL "$url" | node "$DIR"/generate.js >"$RESULT"

--- a/test/markProcessor.test.ts
+++ b/test/markProcessor.test.ts
@@ -14,7 +14,7 @@ t.test('MarkProcessor', async (t) => {
   t.test('throws when an unknown handler is called', async () => {
     const marks = [{name: 'invalid', position: 0}]
     const input = ''
-    const processor = new MarkProcessor(input, marks, {})
+    const processor = new MarkProcessor(input, marks, {}, {})
 
     throwsWithMessage(t, () => processor.process(TestVisitor), 'Unknown handler: invalid')
   })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -282,3 +282,26 @@ t.test('Delta-GROQ', async (t) => {
 t.test('handles parenthesis inside filters (regression bug)', async (t) => {
   t.doesNotThrow(() => parse('*[(_type == "foo")]'))
 })
+
+t.test('Custom functions', async (t) => {
+  await t.test('can parse', async (t) => {
+    const expr = parse(`fn foo::info($person) = $person{name, "names": foo::name(name), age};
+         fn foo::name($names) = $names[]{first, last};
+         *[_type == "person"] {
+           "info": foo::info(@)
+         }
+    `)
+    t.matchSnapshot(expr)
+  })
+
+  await t.test('detects recursion', async (t) => {
+    t.throws(() =>
+      parse(`fn foo::f1($person) = $person{name, "names": foo::f1(name), age};
+         fn foo::f2($names) = $names[]{first, last, "f1": foo::f1(name)};
+         *[_type == "person"] {
+           ...foo::f1(@)
+         }
+    `),
+    )
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Alternative to #308 

Adds support for parsing custom functions by using marks to replace during parsing. Replaces all the custom function definition during mark processing

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
Added som basic tests to the parser, and enabled custom functions tests from the groq test suite
