### PR TITLE
fix(typeEvaluator): handle splatting arrays

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -887,7 +887,14 @@ function handleArrayNode(node: ArrayNode, scope: Scope): TypeNode {
   const of: TypeNode[] = []
   for (const el of node.elements) {
     const node = walk({node: el.value, scope})
-    if (node !== null) {
+    if (el.isSplat) {
+      // if we are splatting a non-array, we ignore it since it would result in no values
+      if (node.type !== 'array') {
+        continue
+      }
+
+      of.push(node.of)
+    } else {
       of.push(node)
     }
   }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3674,6 +3674,29 @@ t.test('deref inline in rest', (t) => {
   t.end()
 })
 
+t.test('splatting array', (t) => {
+  const ast = parse(`[
+    ...[0,1,2],
+    ...[3,4,5],
+    ...{"key": "value"},
+    ...{},
+    ...null
+  ]`)
+  const res = typeEvaluate(ast, [])
+  t.strictSame(res, {
+    type: 'array',
+    of: unionOf(
+      {type: 'number', value: 0},
+      {type: 'number', value: 1},
+      {type: 'number', value: 2},
+      {type: 'number', value: 3},
+      {type: 'number', value: 4},
+      {type: 'number', value: 5},
+    ),
+  })
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
### Description

We didn't handle the case where an array was splatting an array element, this lead to `[...[1]]` being typed as `Array<Array<1>>` instead of `Array<1>`

It should now match the evaluator in https://github.com/sanity-io/groq-js/blob/main/src/evaluator/evaluate.ts#L606-L611

### Testing

Added
