### PR TITLE
Add support for parsing and type evaluating media::aspect

### DIFF
--- a/src/evaluator/functions/index.ts
+++ b/src/evaluator/functions/index.ts
@@ -1,5 +1,5 @@
 import {type ExprNode} from '../../nodeTypes'
-import {StreamValue, type ArrayValue} from '../../values'
+import {type ArrayValue, StreamValue} from '../../values'
 import type {Executor} from '../types'
 import array from './array'
 import dateTime from './dateTime'
@@ -9,6 +9,7 @@ import documents from './documents'
 import geo from './geo'
 import _global from './global'
 import math from './math'
+import media from './media'
 import pt from './pt'
 import releases from './releases'
 import sanity from './sanity'
@@ -47,6 +48,7 @@ export const namespaces: NamespaceSet = {
   pt,
   delta,
   diff,
+  media,
   sanity,
   math,
   dateTime,

--- a/src/evaluator/functions/media.ts
+++ b/src/evaluator/functions/media.ts
@@ -1,0 +1,10 @@
+import {constantExecutor} from '../evaluate'
+import type {FunctionSet} from '.'
+
+const media: FunctionSet = {}
+media['aspect'] = constantExecutor(() => {
+  throw new Error('not implemented')
+})
+media['aspect'].arity = 2
+
+export default media

--- a/src/typeEvaluator/functions.ts
+++ b/src/typeEvaluator/functions.ts
@@ -514,6 +514,21 @@ export function handleFuncCallNode(node: FuncCallNode, scope: Scope): TypeNode {
     case 'documents.incomingGlobalDocumentReferenceCount': {
       return {type: 'number'}
     }
+    case 'media.aspect': {
+      return mapNode(walk({node: node.args[0], scope}), scope, (fieldNode) => {
+        if (fieldNode.type === 'null') {
+          return {type: 'null'}
+        }
+
+        return mapNode(walk({node: node.args[1], scope}), scope, (aspectNode) => {
+          if (aspectNode.type !== 'string') {
+            return {type: 'null'}
+          }
+
+          return {type: 'unknown'}
+        })
+      })
+    }
     default: {
       return {type: 'unknown'}
     }

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3027,6 +3027,44 @@ t.test('function: documents::*', (t) => {
   t.end()
 })
 
+t.test('function: media::*', (t) => {
+  const query = `*[_type == "post"] {
+    "missing":  media::aspect(missing, "license"),
+    "number":   media::aspect(author, 1234),
+    "aspect":   media::aspect(author, "license"),
+  }`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+
+  t.strictSame(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        missing: {
+          type: 'objectAttribute',
+          value: {
+            type: 'null',
+          },
+        },
+        number: {
+          type: 'objectAttribute',
+          value: {
+            type: 'null',
+          },
+        },
+        aspect: {
+          type: 'objectAttribute',
+          value: {
+            type: 'unknown',
+          },
+        },
+      },
+    },
+  })
+  t.end()
+})
+
 t.test('scoping', (t) => {
   const ast = parse(`*[_type == "mainDocument" && _id == $id]{
     _id,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds support for parsing and type evaluating media::aspect.
`globalDocumentRefenrece` type currently evaluates to `unknown` in the schema, so we only check if the first argument is not null(Which means it exists). The second argument must be a string

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
