### PR TITLE
feat(typeEvaluator): add support for number + datetime operation

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -34,7 +34,6 @@ import {optimizeUnions} from './optimizations'
 import {Context, Scope} from './scope'
 import {isFuncCall, mapNode, nullUnion, resolveInline} from './typeHelpers'
 import {
-  STRING_TYPE_DATETIME,
   type ArrayTypeNode,
   type BooleanTypeNode,
   type Document,
@@ -44,6 +43,7 @@ import {
   type ObjectTypeNode,
   type PrimitiveTypeNode,
   type Schema,
+  STRING_TYPE_DATETIME,
   type StringTypeNode,
   type TypeNode,
   type UnionTypeNode,
@@ -619,6 +619,10 @@ function handleOpCallNode(node: OpCallNode, scope: Scope): TypeNode {
           }
           // datetime + number -> datetime (datetimes are represented as strings with STRING_TYPE_DATETIME marker)
           if (left.type === 'string' && left[STRING_TYPE_DATETIME] && right.type === 'number') {
+            return {type: 'string', [STRING_TYPE_DATETIME]: true}
+          }
+          // number + datetime -> datetime (commutative)
+          if (left.type === 'number' && right.type === 'string' && right[STRING_TYPE_DATETIME]) {
             return {type: 'string', [STRING_TYPE_DATETIME]: true}
           }
 

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3746,6 +3746,17 @@ t.test('dateTime with numerical operation', (t) => {
   t.end()
 })
 
+t.test('number + dateTime', (t) => {
+  const query = `(60 + global::dateTime("2025-03-01T00:00:00Z")) > global::dateTime("2024-03-01T00:00:00Z")`
+  const ast = parse(query)
+  const res = typeEvaluate(ast, schemas)
+  t.same(res, {
+    type: 'union',
+    of: [{type: 'boolean', value: undefined}, {type: 'null'}],
+  })
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
### TL;DR

Adds support for commutative addition between numbers and datetime values.

https://linear.app/sanity/issue/CLDX-4468/add-support-for-number-datetime-in-groq-js

### What changed?

`number + datetime` is now supported in addition to `datetime + number`

### How to test?

Run the new test case that verifies a datetime can be added to a number:

```typescript
t.test('number + dateTime', (t) => {
  const query = `(60 + global::dateTime("2025-03-01T00:00:00Z")) > global::dateTime("2024-03-01T00:00:00Z")`
  const ast = parse(query)
  const res = typeEvaluate(ast, schemas)
  t.same(res, {
    type: 'union',
    of: [{type: 'boolean', value: undefined}, {type: 'null'}],
  })
  t.end()
})
```

### Why make this change?

Gradient supports these operations (even though they're not defined in the spec). We should update the spec too, but this change at least gets `groq-js` in line with the actual query engine behaviour, which is what users expect.