### PR TITLE
feat: include line/column info on groq syntax errors

### DIFF
--- a/src/1.ts
+++ b/src/1.ts
@@ -9,7 +9,7 @@ export type {
   Executor,
 } from './evaluator/types'
 export * from './nodeTypes'
-export {parse} from './parser'
+export {GroqSyntaxError, parse} from './parser'
 export type {ParseOptions} from './types'
 export {unparse} from './unparse'
 export type {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1000,13 +1000,46 @@ function argumentShouldBeSelector(namespace: string, functionName: string, argCo
   return namespace == 'diff' && argCount == 2 && functionsRequiringSelectors.includes(functionName)
 }
 
-class GroqSyntaxError extends Error {
+/**
+ * Error thrown when a GROQ query contains a syntax error.
+ *
+ * Provides the position of the error as both a string offset and
+ * a line/column pair. All values use UTF-16 code unit offsets,
+ * matching JavaScript string indexing and the LSP default encoding.
+ */
+export class GroqSyntaxError extends Error {
+  /**
+   * 0-based UTF-16 code unit offset from the start of the query string.
+   */
   public position: number
+
+  /**
+   * 1-based line number where the error occurred.
+   */
+  public line: number
+
+  /**
+   * 1-based column number within the line, in UTF-16 code units.
+   */
+  public column: number
+
   public override name = 'GroqSyntaxError'
 
-  constructor(position: number, detail: string) {
+  constructor(position: number, query: string, detail: string) {
     super(`Syntax error in GROQ query at position ${position}${detail ? `: ${detail}` : ''}`)
     this.position = position
+
+    let line = 1
+    let lineStart = 0
+    for (let i = 0; i < position && i < query.length; i++) {
+      if (query[i] === '\n') {
+        line++
+        lineStart = i + 1
+      }
+    }
+
+    this.line = line
+    this.column = position - lineStart + 1
   }
 }
 
@@ -1016,7 +1049,7 @@ class GroqSyntaxError extends Error {
 export function parse(input: string, options: ParseOptions = {}): ExprNode {
   const result = rawParse(input)
   if (result.type === 'error') {
-    throw new GroqSyntaxError(result.position, result.message)
+    throw new GroqSyntaxError(result.position, input, result.message)
   }
   validateCustomFunctions(input, result.customFunctions)
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 
-import {parse} from '../src/1'
+import {GroqSyntaxError, parse} from '../src/1'
 import {throwsWithMessage} from './testUtils'
 
 t.test('Basic parsing', async (t) => {
@@ -59,14 +59,31 @@ t.test('Basic parsing', async (t) => {
 
 t.test('Error reporting', async (t) => {
   t.test('when querying with a syntax error', async (t) => {
-    t.plan(3)
+    t.plan(5)
     const query = `*[_type == "]`
     try {
       parse(query)
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (!(error instanceof GroqSyntaxError)) throw error
       t.same(error.name, 'GroqSyntaxError')
       t.same(error.position, 13)
+      t.same(error.line, 1)
+      t.same(error.column, 14)
       t.same(error.message, 'Syntax error in GROQ query at position 13: Unexpected end of query')
+    }
+  })
+
+  t.test('reports correct line and column for multiline queries', async (t) => {
+    t.plan(4)
+    const query = `*[\n  _type ==\n  "]`
+    try {
+      parse(query)
+    } catch (error: unknown) {
+      if (!(error instanceof GroqSyntaxError)) throw error
+      t.same(error.position, 18)
+      t.same(error.line, 3)
+      t.same(error.column, 5)
+      t.same(error.message, 'Syntax error in GROQ query at position 18: Unexpected end of query')
     }
   })
 })


### PR DESCRIPTION
### Description

Add `line` and `column` properties to `GroqSyntaxError`, computed from the existing `position` offset and the query string. This lets consumers display human-readable error locations (e.g. for editor integration) without having to recompute line/column themselves.

Also exports `GroqSyntaxError` from the package entry point so consumers can use `instanceof` narrowing to access the error properties in a type-safe way.

- `line`: 1-based line number
- `column`: 1-based column number within the line
- Both use UTF-16 code unit offsets, consistent with JS string indexing and the LSP default position encoding

### What to review

-  The line/column computation in the `GroqSyntaxError` constructor - verify the loop logic handles edge cases (position at newline, position past end of string, position 0)
- New `GroqSyntaxError` export - this is a new addition to the public API surface, but feels like a good addition (accessing `position`, `line` and `column` without having to do manual type narrowing)
- Whether UTF-16 code units is the right unit for `column`, or if code point counting (`for...of`) would be more appropriate. In practice this only differs when there are surrogate pairs (like certain emoji, rare CJK extensions) before the error on the same line, which is unlikely in GROQ queries - but worth a conscious decision. I went with UTF-16 code unit offsets since it matches the language server protocol position encoding. If needed the user can still compute the code points if needed.

### Testing

Added two test cases in `test/parse.test.ts`:
- Single-line query: verifies `line` and `column` alongside existing `position` and `message` assertions
- Multiline query: verifies correct line/column computation across newline boundaries

Both tests use `instanceof GroqSyntaxError` narrowing instead of the previous `error: any` pattern.
