### PR TITLE
fix: handle sliced dereference projections in unparse

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -906,6 +906,7 @@ function extractPropertyKey(node: ExprNode): string {
     node.type === 'PipeFuncCall' ||
     node.type === 'Deref' ||
     node.type === 'Map' ||
+    node.type === 'FlatMap' ||
     node.type === 'Projection' ||
     node.type === 'Slice' ||
     node.type === 'Filter' ||

--- a/src/unparse.ts
+++ b/src/unparse.ts
@@ -282,6 +282,11 @@ function unparseFlatMapExpr(node: ExprNode): string {
     return `${unparseFlatMapExpr(node.base)}[]`
   }
 
+  if (node.type === 'Slice') {
+    const base = unparseFlatMapExpr(node.base)
+    return `${base}[${node.left}${node.isInclusive ? '..' : '...'}${node.right}]`
+  }
+
   if (node.type === 'Map') {
     const base = unparseFlatMapExpr(node.base)
     const expr = unparseMapExpr(node.expr)
@@ -298,6 +303,9 @@ function unparseFlatMapExpr(node: ExprNode): string {
     if (node.base?.type === 'This') return unparse(node.expr)
     if (node.base?.type === 'Deref' && node.base.base?.type === 'This') {
       return `->${unparse(node.expr)}`
+    }
+    if (node.base?.type === 'Map') {
+      return `${unparseFlatMapExpr(node.base)}${unparse(node.expr)}`
     }
   }
 

--- a/test/unparse.test.ts
+++ b/test/unparse.test.ts
@@ -16,7 +16,7 @@ t.test('unparse', async () => {
     '*._id',
     'select(1 => 2, foo)',
     'select(1 => 2)',
-    // Sliced dereference projections (SAGE-166)
+    // Sliced dereference projections
     '*[_type == "product"]{faqs[]->{question, answer}[0...3]}',
     '*[_type == "collection"][0]{"products": products[]->{title}[0...10]}',
     '*{faqs[]->{q}[0..3]}',

--- a/test/unparse.test.ts
+++ b/test/unparse.test.ts
@@ -16,6 +16,10 @@ t.test('unparse', async () => {
     '*._id',
     'select(1 => 2, foo)',
     'select(1 => 2)',
+    // Sliced dereference projections (SAGE-166)
+    '*[_type == "product"]{faqs[]->{question, answer}[0...3]}',
+    '*[_type == "collection"][0]{"products": products[]->{title}[0...10]}',
+    '*{faqs[]->{q}[0..3]}',
   ]
 
   for (const query of queries) {


### PR DESCRIPTION
Fixes [SAGE-166](https://linear.app/sanity/issue/SAGE-166).

`unparse()` crashed on queries using the `array[]->{...}[slice]` pattern, and produced invalid GROQ (`@->{...}`) for the simpler variant.

## Changes

- **parser**: `extractPropertyKey` now recurses into `FlatMap` nodes (same shape as `Map`, already in the allowlist). Without this, shorthand object attributes like `{faqs[]->{q}[0...3]}` throw `Cannot determine property key for type: FlatMap`.
- **unparse**: `unparseFlatMapExpr` now handles `Slice` nodes and `Projection` whose base is a `Map`. Previously these fell through to the generic `unparse` which turned `Deref(This)` into `@->`, producing invalid GROQ.

## Verification

Both queries from the issue now round-trip:

```groq
*[_type == "product"]{faqs[]->{question, answer}[0...3]}
-> *[_type == "product"]{"faqs": faqs[]->{"question": question, "answer": answer}[0...3]}

*[_type == "collection"][0]{"products": products[]->{title}[0...10]}
-> *[_type == "collection"][0]{"products": products[]->{"title": title}[0...10]}
```

Full test suite passes (15 test files, ~29k assertions in `suite.test.js` alone).