### PR TITLE
ci: add pkg.pr.new continuous releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -22,4 +22,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm exec pkg-pr-new publish
+      - run: npm exec pkg-pr-new publish --no-template

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -9,7 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read # for checkout
 
 jobs:
   publish:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,25 @@
+name: Continuous Releases
+
+on:
+  push:
+    branches: [main, canary]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm exec pkg-pr-new publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "ndjson": "^2.0.0",
+        "pkg-pr-new": "^0.0.75",
         "prettier": "^3.8.1",
         "rimraf": "^5.0.0",
         "semantic-release": "^24.2.0",
@@ -11714,6 +11715,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.75.tgz",
+      "integrity": "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/pkg-up": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "ndjson": "^2.0.0",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "^3.8.1",
     "rimraf": "^5.0.0",
     "semantic-release": "^24.2.0",


### PR DESCRIPTION
Sets up [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) so every pull request and every push to `main`/`canary` publishes an instant preview release, installable from a pkg.pr.new URL without publishing anything to npm.

## What's included

- **`.github/workflows/pkg-pr-new.yml`** - clean install, `npm run build`, then `npm exec pkg-pr-new publish`. The build runs first because `dist` must exist before publishing: `npm pack` does not run the `prepublishOnly` hook.
- **`package.json`** / **`package-lock.json`** - `pkg-pr-new` added as a devDependency. Per their CI guidance, it's installed from the lockfile and run with `npm exec` rather than `npx`/`dlx`.

## Notes on the setup

- Triggers on `pull_request` plus pushes to `main`/`canary` - deliberately not bare `[push, pull_request]`, which would double-publish on every PR branch push.
- `permissions: {}` - PR comments and check runs come from the pkg.pr.new GitHub App, not the workflow token, so no extra permissions are needed.
- Compact URLs work out of the box since `groq-js` is on npm with a valid `repository` field, so previews install as `npm i https://pkg.pr.new/groq-js@<sha>`.

## Required before this works

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on `sanity-io/groq-js`. It needs to be installed before the first publish runs, or the workflow step will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)