### PR TITLE
docs: fix typo in API example

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,7 +44,7 @@ interface EvaluateOptions {
   // The value that will be available as `*` in GROQ.
   dataset?: any
 
-  // Parameters availble in the GROQ query (using `$param` syntax).
+  // Parameters available in the GROQ query (using `$param` syntax).
   params?: Record<string, unknown>
 
   // Timestamp used for now().


### PR DESCRIPTION
Fixes a small typo in the API example comment: `availble` → `available`.

This is a documentation-only change.