### PR TITLE
docs: fix typo "availble" → "available"

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,7 +44,7 @@ interface EvaluateOptions {
   // The value that will be available as `*` in GROQ.
   dataset?: any
 
-  // Parameters availble in the GROQ query (using `$param` syntax).
+  // Parameters available in the GROQ query (using `$param` syntax).
   params?: Record<string, unknown>
 
   // Timestamp used for now().


### PR DESCRIPTION
Simple documentation typo fix.

## Change
- Fix typo  →  in 
- 1 file changed, small documentation fix