### PR TITLE
docs: fix typo availble → available in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,7 +44,7 @@ interface EvaluateOptions {
   // The value that will be available as `*` in GROQ.
   dataset?: any
 
-  // Parameters availble in the GROQ query (using `$param` syntax).
+  // Parameters available in the GROQ query (using `$param` syntax).
   params?: Record<string, unknown>
 
   // Timestamp used for now().


### PR DESCRIPTION
This PR fixes a simple typo:  →  in API documentation.

No functional changes, just a small documentation improvement.