### PR TITLE
fix(parse): only throw if function param is used >1 times

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -417,7 +417,7 @@ function createExpressionBuilder(
         validateArity(name, funcDecl.params.length, args.length)
         return mapCustomFunction(
           funcDecl.body,
-          (body) => walkValidateCustomFunction(body),
+          (body) => walkValidateCustomFunction(body, funcDecl.params),
           (parameterNode) => resolveFunctionParameter(parameterNode, funcDecl.params, args),
         )
       }
@@ -1121,6 +1121,6 @@ function validateCustomFunctions(
 
     const FUNCTION_DECL_BUILDER = createFunctionDeclarationBuilder(parseOptions)
     const funcDecl = processor.process(FUNCTION_DECL_BUILDER)
-    mapCustomFunction(funcDecl.body, (body) => walkValidateCustomFunction(body))
+    mapCustomFunction(funcDecl.body, (body) => walkValidateCustomFunction(body, funcDecl.params))
   }
 }

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,23 +1,24 @@
-import {type ExprNode, type SelectorNode} from './shared/nodeTypes'
+import {type ExprNode, type ParameterNode, type SelectorNode} from './shared/nodeTypes'
 
 // eslint-disable-next-line complexity
 export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
   node: T,
+  functionParameters: ParameterNode[],
   level: number = 0,
 ): T {
   switch (node.type) {
     case 'Projection': {
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
-        expr: walkValidateCustomFunction(node.expr, level + 1),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
+        expr: walkValidateCustomFunction(node.expr, functionParameters, level + 1),
       }
     }
     case 'Filter': {
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
-        expr: walkValidateCustomFunction(node.expr, level + 1),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
+        expr: walkValidateCustomFunction(node.expr, functionParameters, level + 1),
       }
     }
     case 'Parent': {
@@ -30,9 +31,12 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
     }
 
     case 'Parameter': {
-      throw new Error(
-        `Function parameters are not allowed outside function declarations: ${node.name}`,
-      )
+      if (functionParameters.find((p) => p.name === node.name)) {
+        throw new Error(
+          `Function parameters are not allowed outside function declarations: ${node.name}`,
+        )
+      }
+      return node
     }
 
     case 'Array':
@@ -40,14 +44,14 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
         ...node,
         elements: node.elements.map((el) => ({
           ...el,
-          value: walkValidateCustomFunction(el.value, level),
+          value: walkValidateCustomFunction(el.value, functionParameters, level),
         })),
       }
     case 'PipeFuncCall': {
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
-        args: node.args.map((arg) => walkValidateCustomFunction(arg, level)),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
+        args: node.args.map((arg) => walkValidateCustomFunction(arg, functionParameters, level)),
       }
     }
 
@@ -59,18 +63,18 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
             case 'ObjectAttributeValue':
               return {
                 ...attr,
-                value: walkValidateCustomFunction(attr.value, level),
+                value: walkValidateCustomFunction(attr.value, functionParameters, level),
               }
             case 'ObjectConditionalSplat':
               return {
                 ...attr,
-                condition: walkValidateCustomFunction(attr.condition, level),
-                value: walkValidateCustomFunction(attr.value, level),
+                condition: walkValidateCustomFunction(attr.condition, functionParameters, level),
+                value: walkValidateCustomFunction(attr.value, functionParameters, level),
               }
             case 'ObjectSplat':
               return {
                 ...attr,
-                value: walkValidateCustomFunction(attr.value, level),
+                value: walkValidateCustomFunction(attr.value, functionParameters, level),
               }
             default:
               return attr
@@ -82,34 +86,36 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
     case 'Map': {
       return {
         ...node,
-        expr: walkValidateCustomFunction(node.expr, level),
-        base: walkValidateCustomFunction(node.base, level),
+        expr: walkValidateCustomFunction(node.expr, functionParameters, level),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
       }
     }
     case 'FuncCall': {
       return {
         ...node,
-        args: node.args.map((arg) => walkValidateCustomFunction(arg, level)),
+        args: node.args.map((arg) => walkValidateCustomFunction(arg, functionParameters, level)),
       }
     }
     case 'Tuple': {
       return {
         ...node,
-        members: node.members.map((member) => walkValidateCustomFunction(member, level)),
+        members: node.members.map((member) =>
+          walkValidateCustomFunction(member, functionParameters, level),
+        ),
       }
     }
 
     case 'Select': {
       const alternatives = node.alternatives.map((alt) => ({
         ...alt,
-        condition: walkValidateCustomFunction(alt.condition, level),
-        value: walkValidateCustomFunction(alt.value, level),
+        condition: walkValidateCustomFunction(alt.condition, functionParameters, level),
+        value: walkValidateCustomFunction(alt.value, functionParameters, level),
       }))
       if (node.fallback) {
         return {
           ...node,
           alternatives,
-          fallback: walkValidateCustomFunction(node.fallback, level),
+          fallback: walkValidateCustomFunction(node.fallback, functionParameters, level),
         }
       }
       return {
@@ -120,13 +126,13 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
     case 'SelectorNested':
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
-        nested: walkValidateCustomFunction(node.nested, level),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
+        nested: walkValidateCustomFunction(node.nested, functionParameters, level),
       }
     case 'SelectorFuncCall':
       return {
         ...node,
-        arg: walkValidateCustomFunction(node.arg, level),
+        arg: walkValidateCustomFunction(node.arg, functionParameters, level),
       }
 
     case 'AccessAttribute':
@@ -145,24 +151,24 @@ export function walkValidateCustomFunction<T extends ExprNode | SelectorNode>(
       }
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
       }
     }
 
     case 'InRange':
       return {
         ...node,
-        base: walkValidateCustomFunction(node.base, level),
-        left: walkValidateCustomFunction(node.left, level),
-        right: walkValidateCustomFunction(node.right, level),
+        base: walkValidateCustomFunction(node.base, functionParameters, level),
+        left: walkValidateCustomFunction(node.left, functionParameters, level),
+        right: walkValidateCustomFunction(node.right, functionParameters, level),
       }
     case 'OpCall':
     case 'And':
     case 'Or':
       return {
         ...node,
-        left: walkValidateCustomFunction(node.left, level),
-        right: walkValidateCustomFunction(node.right, level),
+        left: walkValidateCustomFunction(node.left, functionParameters, level),
+        right: walkValidateCustomFunction(node.right, functionParameters, level),
       }
 
     case 'Parameter':

--- a/tap-snapshots/test/parse.test.ts.test.cjs
+++ b/tap-snapshots/test/parse.test.ts.test.cjs
@@ -383,10 +383,26 @@ Object {
                     "value": "hello",
                   },
                 },
+                Object {
+                  "name": "undefinedParam",
+                  "type": "ObjectAttributeValue",
+                  "value": Object {
+                    "name": "undefinedParam",
+                    "type": "Parameter",
+                  },
+                },
               ],
               "type": "Object",
             },
             "type": "Projection",
+          },
+        },
+        Object {
+          "name": "undefinedParam",
+          "type": "ObjectAttributeValue",
+          "value": Object {
+            "name": "undefinedParam",
+            "type": "Parameter",
           },
         },
       ],

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -309,10 +309,11 @@ t.test('handles parenthesis inside filters (regression bug)', async (t) => {
 t.test('Custom functions', async (t) => {
   await t.test('can parse', async (t) => {
     const expr = parse(
-      `fn foo::info($person) = $person{name, "names": foo::name(name), age, "myparam": $myparam};
+      `fn foo::info($person) = $person{name, "names": foo::name(name), age, "myparam": $myparam, "undefinedParam": $undefinedParam};
          fn foo::name($names) = $names[]{first, last};
          *[_type == "person"] {
-           "info": foo::info(@)
+           "info": foo::info(@),
+           "undefinedParam": $undefinedParam
          }
     `,
       {params: {myparam: 'hello'}},

--- a/test/typeEvaluate.test.ts
+++ b/test/typeEvaluate.test.ts
@@ -3970,6 +3970,54 @@ t.test('match with dateTime in patterns array returns false', (t) => {
   t.end()
 })
 
+t.test('custom functions', (t) => {
+  const ast = parse(
+    `
+    fn foo::info($person) = $person{name, "names": name, "myparam": $myparam};
+    *[_type == "author"] {
+      "info": foo::info(@)
+    }
+  `,
+    {params: {}},
+  )
+  const res = typeEvaluate(ast, schemas)
+  t.same(res, {
+    type: 'array',
+    of: {
+      type: 'object',
+      attributes: {
+        info: {
+          type: 'objectAttribute',
+          value: {
+            type: 'object',
+            attributes: {
+              name: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'string',
+                },
+              },
+              names: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'string',
+                },
+              },
+              myparam: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'unknown',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } satisfies TypeNode)
+  t.end()
+})
+
 function findSchemaType(name: string): TypeNode {
   const type = schemas.find((s) => s.name === name)
   if (!type) {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Only validate use of function parameters, not all parameters. This allows typegen to type global parameters as unknown, and not throw an error.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
updated