### PR TITLE
fix: add missing yaml lockfile entry so npm ci passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,6 +2410,24 @@
         }
       }
     },
+    "node_modules/@sanity/tsdown-config/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/@sanity/vanilla-extract-integration": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@sanity/vanilla-extract-integration/-/vanilla-extract-integration-0.1.5.tgz",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `package-lock.json` on `feat/obug-tsdown` is out of sync: it references vite's optional `yaml` peer dependency (pulled in via `@sanity/tsdown-config`) but has no lock entry for it, so `npm ci` fails with:

```
npm error Missing: yaml@2.9.0 from lock file
```

The CI build matrix uses `npm install` and is unaffected, but the release job runs `npm ci` and would fail at release time. `main`'s lockfile passes `npm ci` cleanly, so this was introduced by the tsdown migration.

This adds the single missing `node_modules/@sanity/tsdown-config/node_modules/yaml` entry (as generated by `npm install`), keeping the rest of the lockfile untouched to avoid churn on the newer-npm `libc` fields.

## Verification

- `npm ci --dry-run` now passes with both npm 10 and npm 11
- `npm run prettify-check`, `npm run build` (tsdown + publint), `npm run test:bundle`, `npm run test:generate`, and `CI=true npm test` (15/15 files) all pass locally on node 22.23
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82bd2f14-0ab5-4354-9995-9f8620ec0283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82bd2f14-0ab5-4354-9995-9f8620ec0283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

