### PR TITLE
tests: fix `unparse()` for some unexpected bases.

### DIFF
--- a/src/unparse.ts
+++ b/src/unparse.ts
@@ -6,9 +6,6 @@ const json = (v: unknown) => JSON.stringify(v)
 
 /** Property accessor: `.name` if identifier-like, else `["name"]` */
 const prop = (name: string) => (isIdent(name) ? `.${name}` : `[${json(name)}]`)
-/** Property accessor with a custom prefix (e.g. `->`) */
-const propWith = (prefix: string, name: string) =>
-  `${prefix}${isIdent(name) ? `.${name}` : `[${json(name)}]`}`
 
 /** Join args with `, ` after unparsing */
 const joinArgs = (args: ExprNode[]) => args.map(unparse).join(', ')
@@ -185,29 +182,12 @@ function unparseSelector(node: ExprNode): string {
 }
 
 function unparseMapExpr(node: ExprNode): string {
-  // AccessAttribute chains with special handling for This/Deref
+  // `This` is the implicit base of a relative traversal expression.
+  if (node.type === 'This') return ''
+
   if (node.type === 'AccessAttribute') {
-    // this.<name> / this["name"]
-    if (node.base?.type === 'This') return prop(node.name)
-
-    // this->.<name> / this->["name"]
-    if (node.base?.type === 'Deref' && node.base.base?.type === 'This') {
-      return propWith('->', node.name)
-    }
-
-    // (this.attr)->.<name> / ...->["name"]
-    if (node.base?.type === 'Deref' && node.base.base?.type === 'AccessAttribute') {
-      const derefBase = unparseMapExpr(node.base.base)
-      return isIdent(node.name)
-        ? `${derefBase}->.${node.name}`
-        : `${derefBase}->[${json(node.name)}]`
-    }
-
-    // Generic attribute or element bases: append property
-    if (node.base?.type === 'AccessAttribute' || node.base?.type === 'AccessElement') {
-      const base = unparseMapExpr(node.base)
-      return `${base}${prop(node.name)}`
-    }
+    const base = node.base ? unparseMapExpr(node.base) : ''
+    return `${base}${prop(node.name)}`
   }
 
   if (node.type === 'AccessElement') {
@@ -215,8 +195,8 @@ function unparseMapExpr(node: ExprNode): string {
     return `${base}[${node.index}]`
   }
 
-  if (node.type === 'Deref' && node.base?.type === 'This') {
-    return '->'
+  if (node.type === 'Deref') {
+    return `${unparseMapExpr(node.base)}->`
   }
 
   if (node.type === 'ArrayCoerce') {
@@ -228,19 +208,7 @@ function unparseMapExpr(node: ExprNode): string {
   }
 
   if (node.type === 'Projection') {
-    if (node.base?.type === 'This') return unparseMapExpr(node.expr)
-
-    if (node.base?.type === 'Deref') {
-      if (node.base.base?.type === 'This') return `->${unparse(node.expr)}`
-      if (node.base.base?.type === 'AccessAttribute') {
-        const derefBase = unparseMapExpr(node.base.base)
-        return `${derefBase}->${unparse(node.expr)}`
-      }
-    }
-
-    if (node.base?.type === 'Projection') {
-      return unparseMapExpr(node.base) + unparse(node.expr)
-    }
+    return unparseMapExpr(node.base) + unparse(node.expr)
   }
 
   if (node.type === 'Map') return unparseMapExpr(node.expr)
@@ -251,26 +219,12 @@ function unparseMapExpr(node: ExprNode): string {
 }
 
 function unparseFlatMapExpr(node: ExprNode): string {
+  // `This` is the implicit base of a relative traversal expression.
+  if (node.type === 'This') return ''
+
   if (node.type === 'AccessAttribute') {
-    // this.<name> / this["name"]
-    if (node.base?.type === 'This') return prop(node.name)
-
-    if (node.base?.type === 'Deref') {
-      // this->.<name> / this->["name"]
-      if (node.base.base?.type === 'This') return propWith('->', node.name)
-
-      // Deref with any base expression: <base>->.<name> / <base>->["name"]
-      const derefBase = unparseFlatMapExpr(node.base.base)
-      return isIdent(node.name)
-        ? `${derefBase}->.${node.name}`
-        : `${derefBase}->[${json(node.name)}]`
-    }
-
-    // Generic attribute/element bases
-    if (node.base?.type === 'AccessAttribute' || node.base?.type === 'AccessElement') {
-      const base = unparseFlatMapExpr(node.base)
-      return `${base}${prop(node.name)}`
-    }
+    const base = node.base ? unparseFlatMapExpr(node.base) : ''
+    return `${base}${prop(node.name)}`
   }
 
   if (node.type === 'AccessElement') {
@@ -300,17 +254,11 @@ function unparseFlatMapExpr(node: ExprNode): string {
   }
 
   if (node.type === 'Projection') {
-    if (node.base?.type === 'This') return unparse(node.expr)
-    if (node.base?.type === 'Deref' && node.base.base?.type === 'This') {
-      return `->${unparse(node.expr)}`
-    }
-    if (node.base?.type === 'Map') {
-      return `${unparseFlatMapExpr(node.base)}${unparse(node.expr)}`
-    }
+    return `${unparseFlatMapExpr(node.base)}${unparse(node.expr)}`
   }
 
-  if (node.type === 'Deref' && node.base?.type === 'This') {
-    return '->'
+  if (node.type === 'Deref') {
+    return `${unparseFlatMapExpr(node.base)}->`
   }
 
   if (node.type === 'Filter') {

--- a/test/unparse.test.ts
+++ b/test/unparse.test.ts
@@ -20,6 +20,13 @@ t.test('unparse', async () => {
     '*[_type == "product"]{faqs[]->{question, answer}[0...3]}',
     '*[_type == "collection"][0]{"products": products[]->{title}[0...10]}',
     '*{faqs[]->{q}[0..3]}',
+    // Relative traversals nested across maps, flat maps, dereferences, and projections
+    '(*[_type=="project"][].members[]->dept->)[budget > 500000].name',
+    '*[_type=="project"][].members[]->dept->[budget > 500000].name',
+    '*[_id == "section-calories"][0] {"options": options[]->{_id, "calories": coalesce(nutrition.calories, ((options[].option->)[_type == "item"])[0].nutrition.calories)}}',
+    '*[_type == "common.procuredOffer" && $brand + "-holidays" in brands && propertyId in $hotelOffers[].propertyId]{..., "matchedOffers": rooms[active == true][].offers[id in $hotelOffers[propertyId == ^.^.propertyId].offerId]{"propertyId": ^.propertyId, "offerId": id}}.matchedOffers[]',
+    '*[_id == "menu-root"][0].defaultMenu->options[]->options[]->{"pickers": *["picker" == ^._type && _id == ^._id]._id}.pickers[]',
+    '*[_id == "settings"][0].resortSelection[defined(resort->slug.current)].resort->{"resortSlug": slug.current}[0...1]',
   ]
 
   for (const query of queries) {


### PR DESCRIPTION
This only comes up with some tests I am working on which aren't currently parsed, like `(*[_type == "project"][].members[]@->.dept->)[budget > 500000].name`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core GROQ stringification for map/flat-map relative paths; behavior is guarded by new round-trip tests but any code depending on exact unparsed text (not just AST) could see different output.
> 
> **Overview**
> **Fixes `unparse()` for complex relative traversals** (nested maps, flat maps, dereferences, and projections) so `parse(unparse(tree))` stays AST-equal for queries that previously broke on “unexpected” bases.
> 
> `unparseMapExpr` and `unparseFlatMapExpr` are refactored to treat **`This` as an implicit empty prefix** in relative traversal context, and to build paths **recursively** for `AccessAttribute`, `Deref`, and `Projection` instead of many `this` / `this->` special cases. The unused **`propWith`** helper is removed.
> 
> Round-trip coverage is extended with several real-world-style GROQ queries (grouped filters on dereferenced paths, nested `options[]->`, parent references, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9979ad5f3f33879f005169f1ce70725dc4a3ac71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->