### PR TITLE
fix: fix handling of float subscripts.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -624,6 +624,10 @@ function createExpressionBuilder(
 
       const value = tryConstantEvaluate(expr)
       if (value && value.type === 'number') {
+        if (!Number.isInteger(value.data)) {
+          throw new GroqQueryError('array element access must use an integer')
+        }
+
         return (right) =>
           traverseElement((base) => ({type: 'AccessElement', base, index: value.data}), right)
       }
@@ -661,6 +665,10 @@ function createExpressionBuilder(
         rightValue.type !== 'number'
       ) {
         throw new GroqQueryError('slicing must use constant numbers')
+      }
+
+      if (!Number.isInteger(leftValue.data) || !Number.isInteger(rightValue.data)) {
+        throw new GroqQueryError('slicing must use integer bounds')
       }
 
       return (rhs) =>

--- a/test/generate.cjs
+++ b/test/generate.cjs
@@ -259,7 +259,8 @@ process.stdin
           write('tt.match(parsed, tree)')
         }
       } else {
-        write(`tt.throws(() => parse(query))`)
+        write(`let params = ${JSON.stringify(entry.params || {})}`)
+        write(`tt.throws(() => parse(query, {params}))`)
       }
       closeStack()
       space()

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -222,9 +222,43 @@ t.test('Expression parsing', async (t) => {
     })
   })
 
+  t.test('when parsing element access', async (t) => {
+    t.test('throws when an index is not an integer', async (t) => {
+      throwsWithMessage(t, () => parse('*[0.1]'), 'array element access must use an integer')
+      throwsWithMessage(
+        t,
+        () => parse('*[$index]', {params: {index: 0.1}}),
+        'array element access must use an integer',
+      )
+    })
+
+    t.test('allows integer-valued decimals and parameters', async (t) => {
+      t.doesNotThrow(() => parse('*[1.0]'))
+      t.doesNotThrow(() => parse('*[$index]', {params: {index: 1.0}}))
+    })
+  })
+
   t.test('when parsing slices', async (t) => {
     t.test('throws when a constant number is not used', async (t) => {
       throwsWithMessage(t, () => parse('*[0..x]'), 'slicing must use constant numbers')
+    })
+
+    t.test('throws when a slice bound is not an integer', async (t) => {
+      const queries = [
+        {query: '*[0.1..2]', params: {}},
+        {query: '*[0..1.5]', params: {}},
+        {query: '*[$from..2]', params: {from: 0.1}},
+        {query: '*[0..$to]', params: {to: 1.5}},
+      ]
+
+      for (const {query, params} of queries) {
+        throwsWithMessage(t, () => parse(query, {params}), 'slicing must use integer bounds')
+      }
+    })
+
+    t.test('allows integer-valued decimals and parameters', async (t) => {
+      t.doesNotThrow(() => parse('*[0.0..2.0]'))
+      t.doesNotThrow(() => parse('*[$from..$to]', {params: {from: 0.0, to: 2.0}}))
     })
   })
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parse-time validation only; rejects previously accepted invalid queries without changing evaluation of valid integer indices.
> 
> **Overview**
> Tightens parse-time validation for **array element access** and **slices** when the subscript or bounds fold to constant numbers (including via `$params`).
> 
> Non-integer numeric indices now fail with `array element access must use an integer`, and slice endpoints with `slicing must use integer bounds`. Values that are mathematically integers but written as decimals (e.g. `1.0`, `$index: 1.0`) still parse successfully.
> 
> Test coverage adds explicit cases in `parse.test.ts`, and the groq-test-suite generator passes `params` into `parse` for invalid tests so parameterized failure cases are exercised correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723f930b411f0e07603988c0864e7bcfa51ee17b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->