### PR TITLE
fix(build): emit declarations for the shared and evaluator chunks

### DIFF
--- a/test/bundle.check.ts
+++ b/test/bundle.check.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
-import {existsSync} from 'node:fs'
-import {dirname, join} from 'node:path'
+import {execFileSync} from 'node:child_process'
+import {existsSync, readFileSync} from 'node:fs'
+import {dirname, join, posix} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import {buildSync} from 'esbuild'
@@ -50,3 +51,28 @@ for (const id of evaluatorIdentifiers) {
 assert.match(bundle, /parse/, 'bundle should contain parse-related code')
 
 console.log('Bundle check passed: evaluator is tree-shaken from parse-only bundle.')
+
+// Declarations are code-split like the runtime, so every relative specifier
+// in a published .d.ts must resolve to a published .d.ts. An unresolvable
+// specifier degrades to TypeScript's `error` type, which `skipLibCheck`
+// silences, leaving consumers with implicit `any`.
+// https://github.com/sanity-io/groq-js/issues/361
+
+const root = join(__dirname, '..')
+const [{files}] = JSON.parse(
+  execFileSync('npm', ['pack', '--dry-run', '--json'], {cwd: root, encoding: 'utf-8'}),
+)
+const published = new Set<string>(files.map((file: {path: string}) => file.path))
+
+const missing: string[] = []
+for (const path of published) {
+  if (!path.endsWith('.d.ts')) continue
+  const source = readFileSync(join(root, path), 'utf-8')
+  for (const [, specifier] of source.matchAll(/(?:from\s*|import\()\s*['"](\.[^'"]+)['"]/g)) {
+    const declaration = posix.join(posix.dirname(path), specifier.replace(/\.[cm]?js$/, '.d.ts'))
+    if (!published.has(declaration)) missing.push(`${path} imports ${specifier}`)
+  }
+}
+assert.deepEqual(missing, [], 'every .d.ts specifier must resolve to a published declaration')
+
+console.log('Declaration check passed: every published .d.ts specifier resolves.')

--- a/test/bundle.check.ts
+++ b/test/bundle.check.ts
@@ -52,10 +52,9 @@ assert.match(bundle, /parse/, 'bundle should contain parse-related code')
 
 console.log('Bundle check passed: evaluator is tree-shaken from parse-only bundle.')
 
-// Declarations are code-split like the runtime, so every relative specifier
-// in a published .d.ts must resolve to a published .d.ts. An unresolvable
-// specifier degrades to TypeScript's `error` type, which `skipLibCheck`
-// silences, leaving consumers with implicit `any`.
+// Code splitting gives published .d.ts files cross-chunk relative imports.
+// If one doesn't resolve, TypeScript degrades it to the `error` type,
+// `skipLibCheck` silences it, and consumers get implicit `any`.
 // https://github.com/sanity-io/groq-js/issues/361
 
 const root = join(__dirname, '..')

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -16,8 +16,16 @@ export default mergeConfig(
       // Split build into shared + evaluator chunks for tree-shaking.
       // Consumers who only import parse() can tree-shake the evaluator
       // chunk, since the entry only references it for evaluate exports.
+      //
+      // rolldown-plugin-dts generates declarations as virtual .d.ts modules
+      // in the same graph and only emits a chunk as .d.ts when the chunk
+      // name ends in `.d`. The `.d` groups must come first, or the
+      // declaration modules land in the runtime chunks and never emit:
+      // https://github.com/sxzz/rolldown-plugin-dts#code-splitting-support
       advancedChunks: {
         groups: [
+          {name: 'shared.d', test: /src[\\/]shared[\\/].*\.d\.[cm]?ts$/},
+          {name: 'evaluator.d', test: /src[\\/]evaluator[\\/].*\.d\.[cm]?ts$/},
           {name: 'shared', test: /src[\\/]shared[\\/]/},
           {name: 'evaluator', test: /src[\\/]evaluator[\\/]/},
         ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Closes #361.

`groq-js@2.0.0` publishes `dist/index.d.ts` with imports from four chunk specifiers, and only two have a matching declaration file in the tarball. `shared-*.d.ts` and `evaluator-*.d.ts` are missing. TypeScript degrades the unresolvable imports to the `error` type, `skipLibCheck` suppresses the diagnostic, and `evaluate` plus every type routed through the shared chunk becomes implicit `any` for consumers.

Root cause. rolldown-plugin-dts generates declarations as virtual `.d.ts` modules in the same chunk graph as the runtime, and it emits a chunk as `.d.ts` only when the chunk name ends in `.d`. The directory-based `advancedChunks` tests in `tsdown.config.mts` captured those declaration modules into the runtime `shared` and `evaluator` chunks, which emit as plain `.js`, so the build dropped the declarations. The entry `.d.ts` files kept importing the chunk specifiers anyway. The automatic `1` and `unparse` chunks are named by the plugin itself with the `.d` suffix, which is why exactly the two configured groups broke. A tsdown bump does not help. The latest release (tsdown 0.22.14 with rolldown-plugin-dts 0.27.14) reproduces the same missing files. The `.d` group convention is the [documented contract for code splitting](https://github.com/sxzz/rolldown-plugin-dts#code-splitting-support).

## Scope

- `tsdown.config.mts` adds `shared.d` and `evaluator.d` groups ahead of the runtime groups, so the declaration modules form their own chunks and emit as `shared-<hash>.d.ts` and `evaluator-<hash>.d.ts` with maps.
- `test/bundle.check.ts` gains a declaration completeness check in the existing `test:bundle` CI slot. It lists the files `npm pack` would publish and requires every relative specifier in each published `.d.ts` to map to a published `.d.ts`.

The first commit lands the failing check and the second the fix, so the history reads red then green.

## Tradeoffs

- The check shells out to `npm pack --dry-run --json` instead of scanning `dist/`. That validates the real publish manifest, so `files` or export drift also fails the check.
- The chunk split stays. I also tested removing `advancedChunks` entirely: declarations come back, but the evaluator merges into the common chunk and the parse-only tree-shaking check fails with `parse-only bundle should not contain "executeAsync"`. The split is what keeps the evaluator out of parse-only consumer bundles.

## Blast Radius

The change touches build config and one post-build check, with no runtime source edits. The runtime chunk layout keeps the same group split, and the existing tree-shaking check (parse-only bundle excludes the evaluator) still passes. Until this merges and a release ships, every 2.x install keeps the implicit `any` types described in #361.

## Verification

- Repro on `main` with the locked toolchain. I built, packed, and compared the tarball listing against the specifiers in the entry `.d.ts` files. `shared-*.d.ts` and `evaluator-*.d.ts` are absent, and the new check fails with six unresolvable specifiers.
- Bump check. tsdown 0.22.14 (latest) with the old config still omits both files, so a version bump alone does not fix it. The bump is not part of this PR.
- Fixed build. `npm pack` ships a `.d.ts` and `.d.ts.map` for all four chunks, and the new check passes.
- Consumer compile against the packed tarballs (strict, NodeNext, `skipLibCheck: false`). The pre-fix tarball fails with four TS7016 errors on the shared and evaluator specifiers. An `@ts-expect-error` probe on `evaluate(42)` reports TS2578 there, which proves `evaluate` degraded to `any`. The fixed tarball compiles clean on all three export paths (`groq-js`, `groq-js/1`, `groq-js/experimental`), the probe suppresses a real error again, and a runtime smoke test through `evaluate` returns the queried value.
- `npm test` (full tap suite) and `npm run test:bundle` pass on the fixed build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-861210d0-07d1-450f-9f20-7134fb2345c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-861210d0-07d1-450f-9f20-7134fb2345c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

