### PR TITLE
perf: initialize type evaluator loggers lazily

### DIFF
--- a/src/typeEvaluator/typeEvaluate.ts
+++ b/src/typeEvaluator/typeEvaluate.ts
@@ -59,14 +59,33 @@ import {
   type UnknownTypeNode,
 } from './types'
 
-// $trace and $debug log to stdout
-const $trace = createDebug('typeEvaluator:evaluate:trace', {
-  log: console.log.bind(console), // eslint-disable-line no-console
-})
-const $debug = createDebug('typeEvaluator:evaluate:debug', {
-  log: console.log.bind(console), // eslint-disable-line no-console
-})
-const $warn = createDebug('typeEvaluator:evaluate:warn')
+type LoggerArgs = Parameters<ReturnType<typeof createDebug>>
+
+let loggers: ReturnType<typeof createLoggers> | undefined
+
+function createLoggers() {
+  return {
+    trace: createDebug('typeEvaluator:evaluate:trace', {
+      log: console.log.bind(console), // eslint-disable-line no-console
+    }),
+    debug: createDebug('typeEvaluator:evaluate:debug', {
+      log: console.log.bind(console), // eslint-disable-line no-console
+    }),
+    warn: createDebug('typeEvaluator:evaluate:warn'),
+  }
+}
+
+function $trace(...args: LoggerArgs) {
+  ;(loggers ??= createLoggers()).trace(...args)
+}
+
+function $debug(...args: LoggerArgs) {
+  ;(loggers ??= createLoggers()).debug(...args)
+}
+
+function $warn(...args: LoggerArgs) {
+  ;(loggers ??= createLoggers()).warn(...args)
+}
 
 /**
  * Evaluates the type of a query and schema.


### PR DESCRIPTION
Importing only `parse` from the built package retains `obug`: the parser and type evaluator share a chunk, and the top-level logger factory calls cannot be discarded safely by bundlers.

Create the three type-evaluator loggers on the first logging call and cache them for subsequent calls. This lets parser-only consumers drop the logging dependency while type evaluation continues to use the existing logger namespaces and options.

With esbuild 0.28.0, browser ESM bundling, minification, and gzip, the parse-only bundle decreases from **10,370 to 9,007 bytes** (**13.1%**). The package entry points and public API are unchanged.

This is a selective-import tree-shaking improvement, not a reduction in the full-export bundle. The current bundle-stats configuration measures all exports from each package entry point, so it retains type evaluation and its loggers. Its CI report shows **+62 bytes gzip (+0.2%)** for the root and /1 entries, below the significance threshold. The parse-only measurement above uses a consumer that re-exports parse from the existing built entry point; that consumer scenario is not configured in CI.

Validation:

- `npm run build` and `npm run test:bundle` pass.
- All 14 local TAP test files pass with coverage disabled.
- Prettier and `git diff --check` pass.
- An instrumented bundle check confirms zero logger initialization at import, three logger instances on first use, and reuse on subsequent evaluations.
- TypeScript diagnostics match the baseline: 91 existing diagnostics, none added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to when `obug` loggers are constructed; type evaluation and logging semantics stay the same.
> 
> **Overview**
> **Defers type-evaluator debug logger setup** so importing the package without running type evaluation no longer pulls in `obug` at module load.
> 
> The three `$trace` / `$debug` / `$warn` helpers now call a cached `createLoggers()` factory on first use instead of invoking `createDebug` at top level. Logger namespaces and options are unchanged; only initialization timing moves to the first log call.
> 
> This is a bundler tree-shaking tweak for parse-only consumers (not a change to the full public API or evaluation behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80e300be79326fe9f4db46f6cc53e1b8134a072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->